### PR TITLE
Store URIs as URITemplates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "URITemplate.swift"]
+	path = URITemplate.swift
+	url = https://github.com/kylef/URITemplate.swift

--- a/Representor.podspec
+++ b/Representor.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |spec|
 
   spec.subspec 'Core' do |core_spec|
     core_spec.source_files = 'Representor/*.{swift,h}'
+    core_spec.dependency 'URITemplate', '>= 1.0.1', '< 2.0.0'
   end
 
   spec.subspec 'Builder' do |builder_spec|

--- a/Representor.xcodeproj/project.pbxproj
+++ b/Representor.xcodeproj/project.pbxproj
@@ -27,6 +27,27 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		2761ABB51A4337DD00093A2F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2761ABB01A4337DD00093A2F /* URITemplate.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 77356D801A253325002822CF;
+			remoteInfo = URITemplate;
+		};
+		2761ABB71A4337DD00093A2F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2761ABB01A4337DD00093A2F /* URITemplate.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 77356D8B1A253325002822CF;
+			remoteInfo = URITemplateTests;
+		};
+		2761ABB91A4337E400093A2F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2761ABB01A4337DD00093A2F /* URITemplate.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 77356D7F1A253325002822CF;
+			remoteInfo = URITemplate;
+		};
 		770834701A0913860008869E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 7708345A1A0913860008869E /* Project object */;
@@ -37,6 +58,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2761ABB01A4337DD00093A2F /* URITemplate.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = URITemplate.xcodeproj; path = URITemplate.swift/URITemplate.xcodeproj; sourceTree = "<group>"; };
 		770834631A0913860008869E /* Representor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Representor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		770834671A0913860008869E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		770834681A0913860008869E /* Representor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Representor.h; sourceTree = "<group>"; };
@@ -78,9 +100,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2761ABB11A4337DD00093A2F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				2761ABB61A4337DD00093A2F /* URITemplate.framework */,
+				2761ABB81A4337DD00093A2F /* URITemplateTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		770834591A0913860008869E = {
 			isa = PBXGroup;
 			children = (
+				2761ABB01A4337DD00093A2F /* URITemplate.xcodeproj */,
 				770834651A0913860008869E /* Representor */,
 				770834721A0913860008869E /* RepresentorTests */,
 				770834641A0913860008869E /* Products */,
@@ -212,6 +244,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				2761ABBA1A4337E400093A2F /* PBXTargetDependency */,
 			);
 			name = Representor;
 			productName = Representor;
@@ -263,6 +296,12 @@
 			mainGroup = 770834591A0913860008869E;
 			productRefGroup = 770834641A0913860008869E /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 2761ABB11A4337DD00093A2F /* Products */;
+					ProjectRef = 2761ABB01A4337DD00093A2F /* URITemplate.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				770834621A0913860008869E /* Representor */,
@@ -270,6 +309,23 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		2761ABB61A4337DD00093A2F /* URITemplate.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = URITemplate.framework;
+			remoteRef = 2761ABB51A4337DD00093A2F /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2761ABB81A4337DD00093A2F /* URITemplateTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = URITemplateTests.xctest;
+			remoteRef = 2761ABB71A4337DD00093A2F /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		770834611A0913860008869E /* Resources */ = {
@@ -321,6 +377,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		2761ABBA1A4337E400093A2F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = URITemplate;
+			targetProxy = 2761ABB91A4337E400093A2F /* PBXContainerItemProxy */;
+		};
 		770834711A0913860008869E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 770834621A0913860008869E /* Representor */;

--- a/Representor/Adapters/HALAdapter.swift
+++ b/Representor/Adapters/HALAdapter.swift
@@ -7,13 +7,14 @@
 //
 
 import Foundation
+import URITemplate
 
-func parseHALLinks(halLinks:Dictionary<String, Dictionary<String, AnyObject>>) -> Dictionary<String, String> {
-  var links = Dictionary<String, String>()
+func parseHALLinks(halLinks:Dictionary<String, Dictionary<String, AnyObject>>) -> Dictionary<String, URITemplate> {
+  var links = Dictionary<String, URITemplate>()
 
   for (link, options) in halLinks {
     if let href = options["href"] as? String {
-      links[link] = href
+      links[link] = URITemplate(template:href)
     }
   }
 
@@ -46,7 +47,7 @@ extension Representor {
   public init(hal:Dictionary<String, AnyObject>) {
     var hal = hal
 
-    var links = Dictionary<String, String>()
+    var links = Dictionary<String, URITemplate>()
     if let halLinks = hal.removeValueForKey("_links") as? Dictionary<String, Dictionary<String, AnyObject>> {
       links = parseHALLinks(halLinks)
     }
@@ -67,10 +68,17 @@ extension Representor {
     var representation = attributes
 
     if links.count > 0 {
-      var links = Dictionary<String, Dictionary<String, String>>()
+      var links = Dictionary<String, Dictionary<String, AnyObject>>()
 
       for (relation, uri) in self.links {
-        links[relation] = ["href": uri]
+        if uri.variables.count > 0 {
+          links[relation] = [
+            "href": uri.template,
+            "templated": true,
+          ]
+        } else {
+          links[relation] = ["href": uri.template]
+        }
       }
 
       representation["_links"] = links

--- a/Representor/Adapters/SirenAdapter.swift
+++ b/Representor/Adapters/SirenAdapter.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import URITemplate
 
 /// An extension to the Representor to add Siren support
 /// It only supports siren links and properties
@@ -16,13 +17,13 @@ extension Representor {
     self.metadata = [:]
 
     if let sirenLinks = siren["links"] as? [Dictionary<String, AnyObject>] {
-      var links = Dictionary<String, String>()
+      var links = Dictionary<String, URITemplate>()
 
       for link in sirenLinks {
         if let href = link["href"] as? String {
           if let relations = link["rel"] as? [String] {
             for relation in relations {
-              links[relation] = href
+              links[relation] = URITemplate(template:href)
             }
           }
         }
@@ -70,7 +71,7 @@ extension Representor {
       var links = [Dictionary<String, AnyObject>]()
 
       for (name, uri) in self.links {
-        links.append(["rel": [name], "href": uri])
+        links.append(["rel": [name], "href": uri.template])
       }
 
       representation["links"] = links

--- a/Representor/Builder/RepresentorBuilder.swift
+++ b/Representor/Builder/RepresentorBuilder.swift
@@ -7,13 +7,14 @@
 //
 
 import Foundation
+import URITemplate
 
 /// A class used to build a representor using a builder pattern
 public class RepresentorBuilder {
   var transitions = Dictionary<String, Transition>()
   var representors = Dictionary<String, [Representor]>()
   var attributes = Dictionary<String, AnyObject>()
-  var links = Dictionary<String, String>()
+  var links = Dictionary<String, URITemplate>()
   var metadata = Dictionary<String, String>()
 
   /// Adds an attribute
@@ -61,7 +62,7 @@ public class RepresentorBuilder {
   ///
   /// :param: name The name (or relation) for the transition
   /// :param: uri The URI of the transition
-  public func addTransition(name:String, uri:String) {
+  public func addTransition(name:String, uri:URITemplate) {
     let transition = Transition(uri: uri, attributes:[:], parameters:[:])
     transitions[name] = transition
   }
@@ -71,7 +72,7 @@ public class RepresentorBuilder {
   /// :param: name The name (or relation) for the transition
   /// :param: uri The URI of the transition
   /// :param: builder The builder used to create the transition
-  public func addTransition(name:String, uri:String, builder:((TransitionBuilder) -> ())) {
+  public func addTransition(name:String, uri:URITemplate, builder:((TransitionBuilder) -> ())) {
     let transition = Transition(uri: uri, builder)
     transitions[name] = transition
   }
@@ -82,7 +83,7 @@ public class RepresentorBuilder {
   ///
   /// :param: name The name (or relation) for the link
   /// :param: uri The URI of the link
-  public func addLink(name:String, uri:String) {
+  public func addLink(name:String, uri:URITemplate) {
     links[name] = uri
   }
 

--- a/Representor/Builder/TransitionBuilder.swift
+++ b/Representor/Builder/TransitionBuilder.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import URITemplate
 
 /// A class used to build a transition using a builder pattern
 public class TransitionBuilder {
@@ -56,7 +57,7 @@ public class TransitionBuilder {
 
 extension Transition {
   /// An extension to Transition to provide a builder interface for creating a Transition.
-  public init(uri:String, _ block:((builder:TransitionBuilder) -> ())) {
+  public init(uri:URITemplate, _ block:((builder:TransitionBuilder) -> ())) {
     let builder = TransitionBuilder()
 
     block(builder: builder)

--- a/Representor/Representor.swift
+++ b/Representor/Representor.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import URITemplate
 
 public struct Representor : Equatable, Hashable {
   /// The transitions available for the representor
@@ -15,14 +16,14 @@ public struct Representor : Equatable, Hashable {
   /// The separate representors embedded in the current representor.
   public let representors:Dictionary<String, [Representor]>
 
-  public let links:Dictionary<String, String>
+  public let links:Dictionary<String, URITemplate>
 
   public let metadata:Dictionary<String, String>
 
   /// The attributes of the representor
   public let attributes:Dictionary<String, AnyObject>
 
-  public init(transitions:Dictionary<String, Transition>, representors:Dictionary<String, [Representor]>, attributes:Dictionary<String, AnyObject>, links:Dictionary<String, String>, metadata:Dictionary<String, String>) {
+  public init(transitions:Dictionary<String, Transition>, representors:Dictionary<String, [Representor]>, attributes:Dictionary<String, AnyObject>, links:Dictionary<String, URITemplate>, metadata:Dictionary<String, String>) {
     self.transitions = transitions
     self.representors = representors
     self.attributes = attributes

--- a/Representor/Transition.swift
+++ b/Representor/Transition.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import URITemplate
 
 public struct InputProperty<T : AnyObject> : Equatable {
   public let defaultValue:T?
@@ -31,12 +32,12 @@ public typealias InputProperties = Dictionary<String, InputProperty<AnyObject>>
 
 /** Transition instances encapsulate information about interacting with links and forms. */
 public struct Transition : Equatable, Hashable {
-  public let uri:String
+  public let uri:URITemplate
 
   public let attributes:InputProperties
   public let parameters:InputProperties
 
-  public init(uri:String, attributes:InputProperties, parameters:InputProperties) {
+  public init(uri:URITemplate, attributes:InputProperties, parameters:InputProperties) {
     self.uri = uri
     self.attributes = attributes
     self.parameters = parameters

--- a/RepresentorTests/Builder/TransitionBuilderTests.swift
+++ b/RepresentorTests/Builder/TransitionBuilderTests.swift
@@ -9,14 +9,15 @@
 import Cocoa
 import XCTest
 import Representor
+import URITemplate
 
 class TransitionBuilderTests: XCTestCase {
   func testTransitionBuildler() {
-    let transition = Transition(uri:"/self/") { builder in
+    let transition = Transition(uri: "/self/") { builder in
 
     }
 
-    XCTAssertEqual(transition.uri, "/self/")
+    XCTAssertEqual(transition.uri, URITemplate(template: "/self/"))
   }
 
   // MARK: Attributes
@@ -26,7 +27,7 @@ class TransitionBuilderTests: XCTestCase {
       builder.addAttribute("name")
     }
 
-    XCTAssertEqual(transition.uri, "/self/")
+    XCTAssertEqual(transition.uri, URITemplate(template: "/self/"))
     XCTAssertTrue(transition.attributes["name"] != nil)
   }
 
@@ -35,7 +36,7 @@ class TransitionBuilderTests: XCTestCase {
       builder.addAttribute("name", value:"Kyle Fuller", defaultValue:nil)
     }
 
-    XCTAssertEqual(transition.uri, "/self/")
+    XCTAssertEqual(transition.uri, URITemplate(template: "/self/"))
     XCTAssertTrue(transition.attributes["name"] != nil)
   }
 
@@ -46,7 +47,7 @@ class TransitionBuilderTests: XCTestCase {
       builder.addParameter("name")
     }
 
-    XCTAssertEqual(transition.uri, "/self/")
+    XCTAssertEqual(transition.uri, URITemplate(template: "/self/"))
     XCTAssertTrue(transition.parameters["name"] != nil)
   }
 
@@ -55,7 +56,7 @@ class TransitionBuilderTests: XCTestCase {
       builder.addParameter("name", value:"Kyle Fuller", defaultValue:nil)
     }
 
-    XCTAssertEqual(transition.uri, "/self/")
+    XCTAssertEqual(transition.uri, URITemplate(template: "/self/"))
     XCTAssertTrue(transition.parameters["name"] != nil)
   }
 }

--- a/RepresentorTests/TransitionTests.swift
+++ b/RepresentorTests/TransitionTests.swift
@@ -9,6 +9,7 @@
 import Cocoa
 import XCTest
 import Representor
+import URITemplate
 
 
 class InputPropertyTests : XCTestCase {
@@ -43,7 +44,7 @@ class TransitionTests : XCTestCase {
   }
 
   func testHasURI() {
-    XCTAssertEqual(transition.uri, "/self/")
+    XCTAssertEqual(transition.uri, URITemplate(template: "/self/"))
   }
 
   func testHasAttributes() {


### PR DESCRIPTION
I'm unsure about this change and would love to get your opinions. Basically means that URI's are also internally stored as URITemplate structures instead of Strings directly. This is because a few of the hypermedia specifications uses URI Templates and it would make sense to provide a unified interface with the format used abstracted away.

Thus, they must always be expanded. They would be used as the following:

``` swift
if let list = representor.transitions["list"] {
  println("You can list with the URI: \(list.uri).")
  let uri = list.uri.expand(["author": "kyle"])
}
```

You can also determine if there are no variables to expand, thus expansion isn't needed:

``` swift
if uri.variables.count == 0 {
  println("We don't need to substitute any variables.")
}
```

But you should just expand it with no variables:

``` swift
uri.expand([:])
```

/cc @fosrias @smizell @zdne
