### PR TITLE
[Representor] Allow custom response deserializer's

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,19 @@ The representor includes adapters to convert between other hypermedia types.
 
 #### NSHTTPURLResponse
 
-You can initialise a representor using an `NSHTTPURLResponse` and the body (`NSData`). It will use the content-type from the response and deserialise the body payload into a format. For unsupported/unknown types, nil will returned.
+You can initialise a representor using a `NSHTTPURLResponse` and the body (`NSData`). It will use the content-type from the response and deserialise the body payload into a format. For unsupported/unknown types, nil will returned.
 
 ```swift
-let representor = Representor(response: response, body: body)
+let representor = Representor.deserialize(response, body: body)
+```
+
+You can register your own, or overide an existing HTTP deserializer for a
+specific content type.
+
+```swift
+Representor.HTTPDeserializers["application/json"] = { response, body in
+  return Representor(...)
+}
 ```
 
 ##### Supported Media Types


### PR DESCRIPTION
This pull request changes the API for how you can deserialise a HTTP response and body to a Representor, allowing us to register our own serialiser or override an existing one.

``` swift
/* Normally this would come from a response from actual server. For example purposes here's how it looks: */
let url = NSURL(string: "http://test.com/")!
let headers = ["Content-Type": "application/hal+json"]
let response = NSHTTPURLResponse(URL: url, statusCode: 200, HTTPVersion: "1.1", headerFields: headers)!
let data = "{\"_links\":{}}".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)!

/* Converting the response and body to an actual representor (using the register deserialisers) */
let representor = Representor.deserialize(response, body: body)
```

---

It also introduced a new API to retrieve the preferred content types (in order) at run-time. So that when making a request to a HTTP server, we know what to send as an `Accept` header.

``` swift
Representor.preferredContentTypes
=> ["application/vnd.siren+json", "application/hal+json"]
```

---

It also allows you to register a deserialiser:

``` swift
Representor.HTTPDeserializers["application/json"] = { (response, data) in
  return /* representor form of the response */
}

Representor.preferredContentTypes.append("application/json")
```
