### PR TITLE
Support deserializing JSON + Link from a HTTP response

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Dependencies/WebLinking.swift"]
+	path = Dependencies/WebLinking.swift
+	url = https://github.com/kylef/WebLinking.swift

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Representor.HTTPDeserializers["application/json"] = { response, body in
 
 - [HAL](http://stateless.co/hal_specification.html) JSON (application/hal+json)
 - [Siren](https://github.com/kevinswiber/siren) JSON (application/vnd.siren+json)
+- [JSON](http://www.json.org) + [Link Headers](http://tools.ietf.org/html/rfc5988) (application/json)
 
 #### HAL
 

--- a/Representor.podspec
+++ b/Representor.podspec
@@ -24,6 +24,7 @@ Pod::Spec.new do |spec|
     adapter_spec.subspec 'Response' do |response_spec|
       response_spec.dependency 'Representor/Adapter/HAL'
       response_spec.dependency 'Representor/Adapter/Siren'
+      response_spec.dependency 'WebLinking'
       response_spec.source_files = 'Representor/Adapters/NSHTTPURLResponseAdapter.swift'
     end
 

--- a/Representor.xcodeproj/project.pbxproj
+++ b/Representor.xcodeproj/project.pbxproj
@@ -32,6 +32,27 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		272A93CD1A6EAB56004B3785 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 272A93C81A6EAB56004B3785 /* WebLinking.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 272A93991A6E67F8004B3785;
+			remoteInfo = WebLinking;
+		};
+		272A93CF1A6EAB56004B3785 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 272A93C81A6EAB56004B3785 /* WebLinking.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 272A93A41A6E67F8004B3785;
+			remoteInfo = WebLinkingTests;
+		};
+		272A93D11A6EAB62004B3785 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 272A93C81A6EAB56004B3785 /* WebLinking.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 272A93981A6E67F8004B3785;
+			remoteInfo = WebLinking;
+		};
 		770834701A0913860008869E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 7708345A1A0913860008869E /* Project object */;
@@ -42,6 +63,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		272A93C81A6EAB56004B3785 /* WebLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = WebLinking.xcodeproj; path = Dependencies/WebLinking.swift/WebLinking.xcodeproj; sourceTree = SOURCE_ROOT; };
 		2774DFDF1A474122008F41CE /* NSHTTPURLResponseAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSHTTPURLResponseAdapter.swift; path = Adapters/NSHTTPURLResponseAdapter.swift; sourceTree = "<group>"; };
 		2774DFE11A474164008F41CE /* NSHTTPURLResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSHTTPURLResponseTests.swift; path = Adapters/NSHTTPURLResponseTests.swift; sourceTree = "<group>"; };
 		279294961A488A24009C52E1 /* UniversalFramework_Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = UniversalFramework_Base.xcconfig; sourceTree = "<group>"; };
@@ -88,6 +110,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		272A93C71A6EAADC004B3785 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				272A93C81A6EAB56004B3785 /* WebLinking.xcodeproj */,
+			);
+			name = Dependencies;
+			sourceTree = "<group>";
+		};
+		272A93C91A6EAB56004B3785 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				272A93CE1A6EAB56004B3785 /* WebLinking.framework */,
+				272A93D01A6EAB56004B3785 /* WebLinkingTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		279294951A488A24009C52E1 /* Configurations */ = {
 			isa = PBXGroup;
 			children = (
@@ -127,6 +166,7 @@
 				770834811A0914CB0008869E /* Transition.swift */,
 				77BC15371A0A69DF00DD24EF /* Builder */,
 				77D643381A0E6D89004D4BA0 /* Adpaters */,
+				272A93C71A6EAADC004B3785 /* Dependencies */,
 				770834661A0913860008869E /* Supporting Files */,
 			);
 			path = Representor;
@@ -235,6 +275,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				272A93D21A6EAB62004B3785 /* PBXTargetDependency */,
 			);
 			name = Representor;
 			productName = Representor;
@@ -286,6 +327,12 @@
 			mainGroup = 770834591A0913860008869E;
 			productRefGroup = 770834641A0913860008869E /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 272A93C91A6EAB56004B3785 /* Products */;
+					ProjectRef = 272A93C81A6EAB56004B3785 /* WebLinking.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				770834621A0913860008869E /* Representor */,
@@ -293,6 +340,23 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		272A93CE1A6EAB56004B3785 /* WebLinking.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = WebLinking.framework;
+			remoteRef = 272A93CD1A6EAB56004B3785 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		272A93D01A6EAB56004B3785 /* WebLinkingTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = WebLinkingTests.xctest;
+			remoteRef = 272A93CF1A6EAB56004B3785 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		770834611A0913860008869E /* Resources */ = {
@@ -349,6 +413,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		272A93D21A6EAB62004B3785 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = WebLinking;
+			targetProxy = 272A93D11A6EAB62004B3785 /* PBXContainerItemProxy */;
+		};
 		770834711A0913860008869E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 770834621A0913860008869E /* Representor */;


### PR DESCRIPTION
These changes allow deserialisation of the content type `application/json` into a representor using the same API has HAL and Siren.

``` swift
let representor = Representor.deserialize(response, body: body)
```

Along with the JSON payload, any [RFC8988](http://tools.ietf.org/html/rfc5988) link headers will be mapped to the Representors links. For example, the following header (as seen in GitHub's API) will be mapped to the next and last relation link in the representor.

```
Link: <https://api.github.com/user/repos?page=3&per_page=100>; rel="next",
      <https://api.github.com/user/repos?page=50&per_page=100>; rel="last"
```

For a JSON document (JSON dictionary), it will cleanly map the JSON attributes to the representers attributes. When the responses JSON body is an array instead of a dictionary, it will be placed in an attribute called `items` inside the Representor. Perhaps there is a better name/mechanism for this?

Potentially we could embed each item in the array as a separate representor and embed them in the root.

---

Note, this behaviour would be customisable by tweaking the deserialiser (calling the original and modifying the returned representor):

``` swift
let originalDeserializer = Representor.HTTPDeserializers["application/json"]
Representor.HTTPDeserializers["application/json"] = { (response, data) in
  let representor = originalDeserializer(response, data)

  return nil /* return a new representor using information from the original */
}
```

Or by completely replacing it's implementation with your own:

``` swift
Representor.HTTPDeserializers["application/json"] = { (response, data) in
  return nil /* return a representor representation of the response and data */
}
```

/cc @fosrias @zdne 
