### PR TITLE
Add ability to parse Blueprint into HTTPTransition

### DIFF
--- a/Representor.podspec
+++ b/Representor.podspec
@@ -16,9 +16,17 @@ Pod::Spec.new do |spec|
   end
 
   spec.subspec 'HTTP' do |http_spec|
-    http_spec.dependency 'Representor/Core'
-    http_spec.dependency 'Representor/Adapter/HAL'
-    http_spec.source_files = 'Representor/HTTP/*.swift', 'Representor/HTTP/Adapters/*.swift'
+    http_spec.subspec 'Core' do |core_spec|
+      core_spec.dependency 'Representor/Core'
+      core_spec.dependency 'Representor/Adapter/HAL'
+      core_spec.source_files = 'Representor/HTTP/*.swift', 'Representor/HTTP/Adapters/*.swift'
+    end
+
+    http_spec.subspec 'APIBlueprint' do |blueprint_spec|
+      blueprint_spec.dependency 'Representor/Core'
+      blueprint_spec.dependency 'Representor/HTTP/Core'
+      blueprint_spec.source_files = 'Representor/HTTP/APIBlueprint/*.swift'
+    end
   end
 
   spec.subspec 'Adapter' do |adapter_spec|

--- a/Representor.xcodeproj/project.pbxproj
+++ b/Representor.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		276A2C001A7BA4B9004BCC6F /* Blueprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276A2BFE1A7BA4B9004BCC6F /* Blueprint.swift */; };
+		276A2C011A7BA4B9004BCC6F /* BlueprintTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276A2BFF1A7BA4B9004BCC6F /* BlueprintTransition.swift */; };
+		276A2C051A7BA4EE004BCC6F /* BlueprintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276A2C031A7BA4EE004BCC6F /* BlueprintTests.swift */; };
+		276A2C061A7BA4EE004BCC6F /* BlueprintTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276A2C041A7BA4EE004BCC6F /* BlueprintTransitionTests.swift */; };
+		276A2C081A7BA500004BCC6F /* blueprint.json in Resources */ = {isa = PBXBuildFile; fileRef = 276A2C071A7BA500004BCC6F /* blueprint.json */; };
 		2774DFE21A474164008F41CE /* NSHTTPURLResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2774DFE11A474164008F41CE /* NSHTTPURLResponseTests.swift */; };
 		279294991A488A24009C52E1 /* UniversalFramework_Base.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 279294961A488A24009C52E1 /* UniversalFramework_Base.xcconfig */; };
 		2792949A1A488A24009C52E1 /* UniversalFramework_Framework.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 279294971A488A24009C52E1 /* UniversalFramework_Framework.xcconfig */; };
@@ -44,6 +49,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		276A2BFE1A7BA4B9004BCC6F /* Blueprint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Blueprint.swift; sourceTree = "<group>"; };
+		276A2BFF1A7BA4B9004BCC6F /* BlueprintTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlueprintTransition.swift; sourceTree = "<group>"; };
+		276A2C031A7BA4EE004BCC6F /* BlueprintTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlueprintTests.swift; sourceTree = "<group>"; };
+		276A2C041A7BA4EE004BCC6F /* BlueprintTransitionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlueprintTransitionTests.swift; sourceTree = "<group>"; };
+		276A2C071A7BA500004BCC6F /* blueprint.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = blueprint.json; sourceTree = "<group>"; };
 		2774DFE11A474164008F41CE /* NSHTTPURLResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSHTTPURLResponseTests.swift; path = Adapters/NSHTTPURLResponseTests.swift; sourceTree = "<group>"; };
 		279294961A488A24009C52E1 /* UniversalFramework_Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = UniversalFramework_Base.xcconfig; sourceTree = "<group>"; };
 		279294971A488A24009C52E1 /* UniversalFramework_Framework.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = UniversalFramework_Framework.xcconfig; sourceTree = "<group>"; };
@@ -92,6 +102,26 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		276A2BFD1A7BA4B9004BCC6F /* API Blueprint */ = {
+			isa = PBXGroup;
+			children = (
+				276A2BFE1A7BA4B9004BCC6F /* Blueprint.swift */,
+				276A2BFF1A7BA4B9004BCC6F /* BlueprintTransition.swift */,
+			);
+			name = "API Blueprint";
+			path = HTTP/APIBlueprint;
+			sourceTree = "<group>";
+		};
+		276A2C021A7BA4EE004BCC6F /* API Blueprint */ = {
+			isa = PBXGroup;
+			children = (
+				276A2C031A7BA4EE004BCC6F /* BlueprintTests.swift */,
+				276A2C041A7BA4EE004BCC6F /* BlueprintTransitionTests.swift */,
+			);
+			name = "API Blueprint";
+			path = APIBlueprint;
+			sourceTree = "<group>";
+		};
 		279294951A488A24009C52E1 /* Configurations */ = {
 			isa = PBXGroup;
 			children = (
@@ -106,6 +136,7 @@
 			isa = PBXGroup;
 			children = (
 				27931A741A727A280084CB47 /* Adapters */,
+				276A2BFD1A7BA4B9004BCC6F /* API Blueprint */,
 				27931A6D1A7271B10084CB47 /* HTTPTransition.swift */,
 				27931A701A7272180084CB47 /* HTTPTransitionBuilder.swift */,
 				27931A721A7272870084CB47 /* HTTPDeserialization.swift */,
@@ -174,6 +205,7 @@
 				770834831A0914E40008869E /* HTTPTransitionTests.swift */,
 				77BC153A1A0A6A7B00DD24EF /* Builder */,
 				77D6433B1A0E6DC5004D4BA0 /* Adapters */,
+				276A2C021A7BA4EE004BCC6F /* API Blueprint */,
 				770834731A0913860008869E /* Supporting Files */,
 			);
 			path = RepresentorTests;
@@ -226,6 +258,7 @@
 		77F592321A1B6E1B0070F839 /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
+				276A2C071A7BA500004BCC6F /* blueprint.json */,
 				77F592341A1B6E1B0070F839 /* poll.hal.json */,
 				77F592351A1B6E1B0070F839 /* poll.siren.json */,
 			);
@@ -334,6 +367,7 @@
 			files = (
 				77F592371A1B6E1B0070F839 /* poll.hal.json in Resources */,
 				77F592381A1B6E1B0070F839 /* poll.siren.json in Resources */,
+				276A2C081A7BA500004BCC6F /* blueprint.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -349,8 +383,10 @@
 				27931A761A727A280084CB47 /* HTTPSirenAdapter.swift in Sources */,
 				770834821A0914CB0008869E /* Transition.swift in Sources */,
 				27931A6E1A7271B10084CB47 /* HTTPTransition.swift in Sources */,
+				276A2C011A7BA4B9004BCC6F /* BlueprintTransition.swift in Sources */,
 				77BC15361A0A69DC00DD24EF /* RepresentorBuilder.swift in Sources */,
 				27931A711A7272180084CB47 /* HTTPTransitionBuilder.swift in Sources */,
+				276A2C001A7BA4B9004BCC6F /* Blueprint.swift in Sources */,
 				77D643371A0E6D7D004D4BA0 /* HALAdapter.swift in Sources */,
 				770834801A09144F0008869E /* Representor.swift in Sources */,
 			);
@@ -366,8 +402,10 @@
 				77D6433A1A0E6DC1004D4BA0 /* HALAdapterTests.swift in Sources */,
 				77F5923A1A1B6F930070F839 /* Utils.swift in Sources */,
 				770834841A0914E40008869E /* HTTPTransitionTests.swift in Sources */,
+				276A2C061A7BA4EE004BCC6F /* BlueprintTransitionTests.swift in Sources */,
 				770834761A0913860008869E /* RepresentorTests.swift in Sources */,
 				77BC15391A0A6A7700DD24EF /* RepresentorBuilderTests.swift in Sources */,
+				276A2C051A7BA4EE004BCC6F /* BlueprintTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Representor/HTTP/APIBlueprint/Blueprint.swift
+++ b/Representor/HTTP/APIBlueprint/Blueprint.swift
@@ -1,0 +1,246 @@
+//
+//  Blueprint.swift
+//  Representor
+//
+//  Created by Kyle Fuller on 06/01/2015.
+//  Copyright (c) 2015 Apiary. All rights reserved.
+//
+
+import Foundation
+
+// MARK: Models
+
+/// A structure representing an API Blueprint AST
+public struct Blueprint {
+  /// Name of the API
+  public let name:String
+
+  /// Top-level description of the API in Markdown (.raw) or HTML (.html)
+  public let description:String?
+
+  /// The collection of resource groups
+  public let resourceGroups:[ResourceGroup]
+
+  public init(name:String, description:String?, resourceGroups:[ResourceGroup]) {
+    self.name = name
+    self.description = description
+    self.resourceGroups = resourceGroups
+  }
+
+  public init(ast:[String:AnyObject]) {
+    name = ast["name"] as String
+    description = ast["description"] as? String
+    resourceGroups = parseBlueprintResourceGroups(ast)
+  }
+
+  public init?(named:String, bundle:NSBundle? = nil) {
+    func loadFile(named:String, bundle:NSBundle) -> [String:AnyObject]? {
+      if let url = bundle.URLForResource(named, withExtension: nil) {
+        if let data = NSData(contentsOfURL: url) {
+          let object: AnyObject? = NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions(0), error: nil)
+          return object as? [String:AnyObject]
+        }
+      }
+
+      return nil
+    }
+
+    let ast = loadFile(named, bundle ?? NSBundle.mainBundle())
+    if let ast = ast {
+      self.init(ast: ast)
+    } else {
+      return nil
+    }
+  }
+}
+
+/// Logical group of resources.
+public struct ResourceGroup {
+  /// Name of the Resource Group
+  public let name:String
+
+  /// Description of the Resource Group (.raw or .html)
+  public let description:String?
+
+  /// Array of the respective resources belonging to the Resource Group
+  public let resources:[Resource]
+
+  public init(name:String, description:String?, resources:[Resource]) {
+    self.name = name
+    self.description = description
+    self.resources = resources
+  }
+}
+
+/// Description of one resource, or a cluster of resources defined by its URI template
+public struct Resource {
+  /// Name of the Resource
+  public let name:String
+
+  /// Description of the Resource (.raw or .html)
+  public let description:String?
+
+  /// URI Template as defined in RFC6570
+  // TODO, make this a URITemplate object
+  public let uriTemplate:String
+
+  /// Array of URI parameters
+  public let parameters:[Parameter]
+
+  /// Array of actions available on the resource each defining at least one complete HTTP transaction
+  public let actions:[Action]
+
+  public init(name:String, description:String?, uriTemplate:String, parameters:[Parameter], actions:[Action]) {
+    self.name = name
+    self.description = description
+    self.uriTemplate = uriTemplate
+    self.actions = actions
+    self.parameters = parameters
+  }
+}
+
+/// Description of one URI template parameter
+public struct Parameter {
+  /// Name of the parameter
+  public let name:String
+
+  /// Description of the Parameter (.raw or .html)
+  public let description:String?
+
+  /// An arbitrary type of the parameter (a string)
+  public let type:String?
+
+  /// Boolean flag denoting whether the parameter is required (true) or not (false)
+  public let required:Bool
+
+  /// A default value of the parameter (a value assumed when the parameter is not specified)
+  public let defaultValue:String?
+
+  /// An example value of the parameter
+  public let example:String?
+
+  /// An array enumerating possible parameter values
+  public let values:[String]?
+
+  public init(name:String, description:String?, type:String?, required:Bool, defaultValue:String?, example:String?, values:[String]?) {
+    self.name = name
+    self.description = description
+    self.type = type
+    self.required = required
+    self.defaultValue = defaultValue
+    self.example = example
+    self.values = values
+  }
+}
+
+// An HTTP transaction (a request-response transaction). Actions are specified by an HTTP request method within a resource
+public struct Action {
+  /// Name of the Action
+  public let name:String
+
+  /// Description of the Action (.raw or .html)
+  public let description:String?
+
+  /// HTTP request method defining the action
+  public let method:String
+
+  /// Array of URI parameters
+  public let parameters:[Parameter]
+
+  public init(name:String, description:String?, method:String, parameters:[Parameter]) {
+    self.name = name
+    self.description = description
+    self.method = method
+    self.parameters = parameters
+  }
+}
+
+// MARK: AST Parsing
+
+func compactMap<C : CollectionType, T>(source: C, transform: (C.Generator.Element) -> T?) -> [T] {
+  var collection = [T]()
+
+  for element in source {
+    if let item = transform(element) {
+      collection.append(item)
+    }
+  }
+
+  return collection
+}
+
+func parseParameter(source:[[String:AnyObject]]?) -> [Parameter] {
+  if let source = source {
+    return source.map { item in
+      let name = item["name"] as String
+      let description = item["description"] as? String
+      let type = item["type"] as? String
+      let required = item["required"] as? Bool
+      let defaultValue = item["default"] as? String
+      let example = item["example"] as? String
+      let values = item["values"] as? [String]
+      return Parameter(name: name, description: description, type: type, required: required ?? true, defaultValue: defaultValue, example: example, values: values)
+    }
+  }
+
+  return []
+}
+
+func parseActions(source:[[String:AnyObject]]?) -> [Action] {
+  if let source = source {
+    return compactMap(source) { item in
+      let name = item["name"] as? String
+      let description = item["description"] as? String
+      let method = item["method"] as? String
+      let parameters = parseParameter(item["parameters"] as? [[String:AnyObject]])
+
+      if let name = name {
+        if let method = method {
+          return Action(name: name, description: description, method: method, parameters: parameters)
+        }
+      }
+
+      return nil
+    }
+  }
+
+  return []
+}
+
+func parseResources(source:[[String:AnyObject]]?) -> [Resource] {
+  if let source = source {
+    return compactMap(source) { item in
+      let name = item["name"] as? String
+      let description = item["description"] as? String
+      let uriTemplate = item["uriTemplate"] as? String
+      let actions = parseActions(item["actions"] as? [[String:AnyObject]])
+      let parameters = parseParameter(item["parameters"] as? [[String:AnyObject]])
+
+      if let name = name {
+        if let uriTemplate = uriTemplate {
+          return Resource(name: name, description: description, uriTemplate: uriTemplate, parameters: parameters, actions: actions)
+        }
+      }
+
+      return nil
+    }
+  }
+
+  return []
+}
+
+private func parseBlueprintResourceGroups(blueprint:Dictionary<String, AnyObject>) -> [ResourceGroup] {
+  if let resourceGroups = blueprint["resourceGroups"] as? [[String:AnyObject]] {
+    return compactMap(resourceGroups) { dictionary in
+      if let name = dictionary["name"] as String? {
+        let resources = parseResources(dictionary["resources"] as? [[String:AnyObject]])
+        let description = dictionary["description"] as String?
+        return ResourceGroup(name: name, description: description, resources: resources)
+      }
+
+      return nil
+    }
+  }
+
+  return []
+}

--- a/Representor/HTTP/APIBlueprint/BlueprintTransition.swift
+++ b/Representor/HTTP/APIBlueprint/BlueprintTransition.swift
@@ -1,0 +1,53 @@
+//
+//  BlueprintTransition.swift
+//  Representor
+//
+//  Created by Kyle Fuller on 28/01/2015.
+//  Copyright (c) 2015 Apiary LTD. All rights reserved.
+//
+
+import Foundation
+
+extension Array {
+  func contains<T : Equatable>(obj: T) -> Bool {
+    let filtered = self.filter {$0 as? T == obj}
+    return filtered.count > 0
+  }
+}
+
+extension Resource {
+  func transition(actionName:String) -> HTTPTransition? {
+    let action = actions.filter{ action in action.name == actionName }.first
+    if let action = action {
+      return HTTPTransition(uri: uriTemplate) { builder in
+        builder.method = action.method
+
+        let addParameter = { (parameter:Parameter) -> Void in
+          let value = parameter.example
+          let defaultValue = (parameter.defaultValue ?? nil) as NSObject?
+          builder.addParameter(parameter.name, value:value, defaultValue:defaultValue)
+        }
+
+        action.parameters.map(addParameter)
+        let parameters = action.parameters.map{ $0.name }
+        self.parameters.filter { !parameters.contains($0.name) }.map(addParameter)
+      }
+    }
+
+    return nil
+  }
+}
+
+/// An extension to Blueprint providing transition conversion
+extension Blueprint {
+  /// Returns a HTTPTransition representation of an action in a resource
+  public func transition(resourceName:String, action actionName:String) -> HTTPTransition? {
+    let resources = resourceGroups.map { resourceGroup in resourceGroup.resources }.reduce([], combine: +)
+    let resource = resources.filter { resource in resource.name == resourceName }.first
+    if let resource = resource {
+      return resource.transition(actionName)
+    }
+
+    return nil
+  }
+}

--- a/RepresentorTests/APIBlueprint/BlueprintTests.swift
+++ b/RepresentorTests/APIBlueprint/BlueprintTests.swift
@@ -1,0 +1,173 @@
+//
+//  BlueprintTests.swift
+//  Representor
+//
+//  Created by Kyle Fuller on 06/01/2015.
+//  Copyright (c) 2015 Apiary. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Representor
+
+
+class ResourceGroupTests : XCTestCase {
+  var resourceGroup:ResourceGroup!
+
+  override func setUp() {
+    resourceGroup = ResourceGroup(name: "Group", description: "Description", resources: [])
+  }
+
+  func testName() {
+    XCTAssertEqual(resourceGroup.name, "Group")
+  }
+
+  func testDescription() {
+    XCTAssertEqual(resourceGroup.description!, "Description")
+  }
+
+  func testResources() {
+    XCTAssertEqual(resourceGroup.resources.count, 0)
+  }
+}
+
+
+class ResourceTests : XCTestCase {
+  var resource:Resource!
+
+  override func setUp() {
+    resource = Resource(name: "Name", description: "Description", uriTemplate: "uri/{template}", parameters: [], actions: [])
+  }
+
+  func testName() {
+    XCTAssertEqual(resource.name, "Name")
+  }
+
+  func testDescription() {
+    XCTAssertEqual(resource.description!, "Description")
+  }
+
+  func testURIemplate() {
+    XCTAssertEqual(resource.uriTemplate, "uri/{template}")
+  }
+
+  func testParameters() {
+    XCTAssertEqual(resource.parameters.count, 0)
+  }
+
+  func testActions() {
+    XCTAssertEqual(resource.actions.count, 0)
+  }
+}
+
+
+class ActionTests : XCTestCase {
+  var action:Action!
+
+  override func setUp() {
+    action = Action(name: "Name", description: "Description", method: "GET", parameters: [])
+  }
+
+  func testName() {
+    XCTAssertEqual(action.name, "Name")
+  }
+
+  func testDescription() {
+    XCTAssertEqual(action.description!, "Description")
+  }
+
+  func testMethod() {
+    XCTAssertEqual(action.method, "GET")
+  }
+
+  func testParameters() {
+    XCTAssertEqual(action.parameters.count, 0)
+  }
+}
+
+
+class ParameterTests : XCTestCase {
+  var parameter:Parameter!
+
+  override func setUp() {
+    parameter = Parameter(name: "Name", description: "Description", type: "string", required: true, defaultValue: "hi", example: "hey", values: nil)
+  }
+
+  func testName() {
+    XCTAssertEqual(parameter.name, "Name")
+  }
+
+  func testDescription() {
+    XCTAssertEqual(parameter.description!, "Description")
+  }
+
+  func testType() {
+    XCTAssertEqual(parameter.type!, "string")
+  }
+
+  func testRequired() {
+    XCTAssertTrue(parameter.required)
+  }
+
+  func testDefaultValue() {
+    XCTAssertEqual(parameter.defaultValue!, "hi")
+  }
+
+  func testExample() {
+    XCTAssertEqual(parameter.example!, "hey")
+  }
+
+  func testValues() {
+    XCTAssertNil(parameter.values)
+  }
+}
+
+
+class BlueprintTests : XCTestCase {
+  func testLoadingNonExistantBlueprint() {
+    let bundle = NSBundle(forClass:object_getClass(self))
+    let blueprint = Blueprint(named:"unknown.json", bundle:bundle)
+    XCTAssertTrue(blueprint == nil)
+  }
+
+  func testParsingBlueprintAST() {
+    let bundle = NSBundle(forClass:object_getClass(self))
+    let blueprint = Blueprint(named:"blueprint.json", bundle:bundle)!
+
+    XCTAssertEqual(blueprint.name, "Requests API")
+    XCTAssertEqual(blueprint.description!, "Following the [Responses](5.%20Responses.md) example, this API will show you how to define multiple requests and what data these requests can bear. Let's demonstrate multiple requests on a trivial example of content negotiation.\n\n## API Blueprint\n\n+ [Previous: Responses](5.%20Responses.md)\n\n+ [This: Raw API Blueprint](https://raw.github.com/apiaryio/api-blueprint/master/examples/6.%20Requests.md)\n\n+ [Next: Parameters](7.%20Parameters.md)\n\n")
+
+    let resourceGroups = blueprint.resourceGroups
+    let resourceGroup = resourceGroups[0]
+    XCTAssertEqual(resourceGroups.count, 1)
+    XCTAssertEqual(resourceGroup.name, "Messages")
+    XCTAssertEqual(resourceGroup.description!, "Group of all messages-related resources.\n\n")
+
+    let resource = resourceGroup.resources[0]
+    XCTAssertEqual(resourceGroup.resources.count, 1)
+    XCTAssertEqual(resource.name, "My Message")
+    XCTAssertEqual(resource.description!, "")
+    XCTAssertEqual(resource.uriTemplate, "/message")
+
+    let retrieveAction = resource.actions[0]
+    let updateAction = resource.actions[1]
+    XCTAssertEqual(resource.actions.count, 2)
+
+    XCTAssertEqual(retrieveAction.name, "Retrieve a Message")
+    XCTAssertEqual(retrieveAction.description!, "In API Blueprint requests can hold exactly the same kind of information and can be described by exactly the same structure as responses, only with different signature – using the `Request` keyword. The string that follows after the `Request` keyword is a request identifier. Again, using an explanatory and simple naming is the best way to go. \n\n")
+    XCTAssertEqual(retrieveAction.method, "GET")
+
+    let parameter = retrieveAction.parameters[0]
+    XCTAssertEqual(parameter.name, "id")
+    XCTAssertEqual(parameter.description!, "An unique identifier of the message.")
+    XCTAssertEqual(parameter.type!, "number")
+    XCTAssertTrue(parameter.required)
+    XCTAssertEqual(parameter.defaultValue!, "")
+    XCTAssertEqual(parameter.example!, "1")
+    XCTAssertEqual(parameter.values!, [])
+
+    XCTAssertEqual(updateAction.name, "Update a Message")
+    XCTAssertEqual(updateAction.description!, "")
+    XCTAssertEqual(updateAction.method, "PUT")
+  }
+}

--- a/RepresentorTests/APIBlueprint/BlueprintTransitionTests.swift
+++ b/RepresentorTests/APIBlueprint/BlueprintTransitionTests.swift
@@ -1,0 +1,30 @@
+//
+//  BlueprintTransitionTests.swift
+//  Representor
+//
+//  Created by Kyle Fuller on 28/01/2015.
+//  Copyright (c) 2015 Apiary LTD. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Representor
+
+class BlueprintTransitionTests: XCTestCase {
+  func testResourceToTransitions() {
+    let parameter = Parameter(name: "name", description: nil, type: "string", required: true, defaultValue: "default", example: "value", values: nil)
+    let action = Action(name: "Create", description: nil, method: "PATCH", parameters: [parameter])
+    let resource = Resource(name: "Post", description: nil, uriTemplate: "/polls", parameters: [parameter], actions: [action])
+    let resourceGroup = ResourceGroup(name: "Name", description: nil, resources: [resource])
+    let blueprint = Blueprint(name: "Blueprint", description: nil, resourceGroups: [resourceGroup])
+
+    let transition = blueprint.transition("Post", action:"Create")!
+    let transitionParameter = transition.parameters["name"]!
+
+    XCTAssertEqual(transition.uri, "/polls")
+    XCTAssertEqual(transition.method, "PATCH")
+    XCTAssertEqual(Array(transition.parameters.keys), ["name"])
+    XCTAssertEqual(transitionParameter.value as String, "value")
+    XCTAssertEqual(transitionParameter.defaultValue as String, "default")
+  }
+}

--- a/RepresentorTests/Fixtures/blueprint.json
+++ b/RepresentorTests/Fixtures/blueprint.json
@@ -1,0 +1,165 @@
+{
+  "_version": "2.1",
+  "metadata": [
+    {
+      "name": "FORMAT",
+      "value": "1A"
+    }
+  ],
+  "name": "Requests API",
+  "description": "Following the [Responses](5.%20Responses.md) example, this API will show you how to define multiple requests and what data these requests can bear. Let's demonstrate multiple requests on a trivial example of content negotiation.\n\n## API Blueprint\n\n+ [Previous: Responses](5.%20Responses.md)\n\n+ [This: Raw API Blueprint](https://raw.github.com/apiaryio/api-blueprint/master/examples/6.%20Requests.md)\n\n+ [Next: Parameters](7.%20Parameters.md)\n\n",
+  "resourceGroups": [
+    {
+      "name": "Messages",
+      "description": "Group of all messages-related resources.\n\n",
+      "resources": [
+        {
+          "name": "My Message",
+          "description": "",
+          "uriTemplate": "/message",
+          "model": {},
+          "parameters": [],
+          "actions": [
+            {
+              "name": "Retrieve a Message",
+              "description": "In API Blueprint requests can hold exactly the same kind of information and can be described by exactly the same structure as responses, only with different signature – using the `Request` keyword. The string that follows after the `Request` keyword is a request identifier. Again, using an explanatory and simple naming is the best way to go. \n\n",
+              "method": "GET",
+              "parameters": [
+                {
+                  "name": "id",
+                  "description": "An unique identifier of the message.",
+                  "type": "number",
+                  "required": true,
+                  "default": "",
+                  "example": "1",
+                  "values": []
+                }
+              ],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [
+                    {
+                      "name": "Plain Text Message",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Accept",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "schema": ""
+                    }
+                  ],
+                  "responses": [
+                    {
+                      "name": "200",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "text/plain"
+                        },
+                        {
+                          "name": "X-My-Message-Header",
+                          "value": "42"
+                        }
+                      ],
+                      "body": "Hello World!\n",
+                      "schema": ""
+                    }
+                  ]
+                },
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [
+                    {
+                      "name": "JSON Message",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Accept",
+                          "value": "application/json"
+                        }
+                      ],
+                      "body": "",
+                      "schema": ""
+                    }
+                  ],
+                  "responses": [
+                    {
+                      "name": "200",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json"
+                        },
+                        {
+                          "name": "X-My-Message-Header",
+                          "value": "42"
+                        }
+                      ],
+                      "body": "{ \"message\": \"Hello World!\" }      \n",
+                      "schema": ""
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "Update a Message",
+              "description": "",
+              "method": "PUT",
+              "parameters": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [
+                    {
+                      "name": "Update Plain Text Message",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "All your base are belong to us.\n",
+                      "schema": ""
+                    },
+                    {
+                      "name": "Update JSON Message",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json"
+                        }
+                      ],
+                      "body": "{ \"message\": \"All your base are belong to us.\" }\n",
+                      "schema": ""
+                    }
+                  ],
+                  "responses": [
+                    {
+                      "name": "204",
+                      "description": "",
+                      "headers": [],
+                      "body": "",
+                      "schema": ""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Usage looks something like this:

``` swift
let blueprint = Blueprint(named: "blueprint.json", bundle: nil)

if let transition = blueprint?.transition("Messages", action: "Create") {
  println("You can create a message with \(transition.method) to the URI: \(transition.uri)")
}
```

You feed in a blueprint AST as JSON, it allows you to grab a HTTPTransition representation of any action inside a resource.
