### PR TITLE
Change initialisers to take optional arrays and dictionaries

### DIFF
--- a/Representor/HTTP/HTTPTransition.swift
+++ b/Representor/HTTP/HTTPTransition.swift
@@ -22,10 +22,10 @@ public struct HTTPTransition : TransitionType {
     public let attributes:InputProperties
     public let parameters:InputProperties
 
-    public init(uri:String, attributes:InputProperties, parameters:InputProperties) {
+    public init(uri:String, attributes:InputProperties? = nil, parameters:InputProperties? = nil) {
         self.uri = uri
-        self.attributes = attributes
-        self.parameters = parameters
+        self.attributes = attributes ?? [:]
+        self.parameters = parameters ?? [:]
         self.suggestedContentTypes = [String]()
     }
 

--- a/Representor/Representor.swift
+++ b/Representor/Representor.swift
@@ -24,12 +24,12 @@ public struct Representor<Transition : TransitionType> : Equatable, Hashable {
   /// The attributes of the representor
   public let attributes:Dictionary<String, AnyObject>
 
-  public init(transitions:Dictionary<String, Transition>, representors:Dictionary<String, [Representor]>, attributes:Dictionary<String, AnyObject>, links:Dictionary<String, String>, metadata:Dictionary<String, String>) {
-    self.transitions = transitions
-    self.representors = representors
-    self.attributes = attributes
-    self.links = links
-    self.metadata = metadata
+  public init(transitions:[String:Transition]? = nil, representors:[String:[Representor]]? = nil, attributes:[String:AnyObject]? = nil, links:[String:String]? = nil, metadata:[String:String]? = nil) {
+    self.transitions = transitions ?? [:]
+    self.representors = representors ?? [:]
+    self.attributes = attributes ?? [:]
+    self.links = links ?? [:]
+    self.metadata = metadata ?? [:]
   }
 
   public var hashValue:Int {

--- a/Representor/Transition.swift
+++ b/Representor/Transition.swift
@@ -33,7 +33,7 @@ public typealias InputProperties = Dictionary<String, InputProperty<AnyObject>>
 public protocol TransitionType : Equatable, Hashable {
   typealias Builder = TransitionBuilderType
 
-  init(uri:String, attributes:InputProperties, parameters:InputProperties)
+  init(uri:String, attributes:InputProperties?, parameters:InputProperties?)
   init(uri:String, _ block:((builder:Builder) -> ()))
 
   var uri:String { get }

--- a/RepresentorTests/HTTPTransitionTests.swift
+++ b/RepresentorTests/HTTPTransitionTests.swift
@@ -39,7 +39,7 @@ class HTTPTransitionTests : XCTestCase {
 
   override func setUp() {
     super.setUp()
-    transition = HTTPTransition(uri:"/self/", attributes:[:], parameters:[:])
+    transition = HTTPTransition(uri:"/self/")
   }
 
   func testHasURI() {
@@ -63,13 +63,13 @@ class HTTPTransitionTests : XCTestCase {
   }
 
   func testEquality() {
-    XCTAssertEqual(transition, HTTPTransition(uri:"/self/", attributes:[:], parameters:[:]))
-    XCTAssertNotEqual(transition, HTTPTransition(uri:"/next/", attributes:[:], parameters:[:]))
+    XCTAssertEqual(transition, HTTPTransition(uri:"/self/"))
+    XCTAssertNotEqual(transition, HTTPTransition(uri:"/next/"))
   }
 
   func testHashValue() {
-    let transition1 = HTTPTransition(uri:"/self/", attributes:[:], parameters:[:])
-    let transition2 = HTTPTransition(uri:"/self/", attributes:[:], parameters:[:])
+    let transition1 = HTTPTransition(uri:"/self/")
+    let transition2 = HTTPTransition(uri:"/self/")
     XCTAssertEqual(transition1.hashValue, transition2.hashValue)
   }
 }

--- a/RepresentorTests/RepresentorTests.swift
+++ b/RepresentorTests/RepresentorTests.swift
@@ -17,8 +17,8 @@ class RepresentorTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-    transition = HTTPTransition(uri:"/self/", attributes:[:], parameters:[:])
-    embeddedRepresentor = Representor(transitions:[:], representors:[:], attributes:[:], links:[:], metadata:[:])
+    transition = HTTPTransition(uri:"/self/")
+    embeddedRepresentor = Representor()
     representor = Representor(transitions:["self": transition], representors:["embedded": [embeddedRepresentor]], attributes:["name":"Kyle"], links:["next": "/next/"], metadata:["key": "value"])
   }
 
@@ -44,12 +44,12 @@ class RepresentorTests: XCTestCase {
 
   func testEquality() {
     XCTAssertEqual(representor, Representor(transitions:["self": transition], representors:["embedded": [embeddedRepresentor]], attributes:["name":"Kyle"], links:["next": "/next/"], metadata:["key": "value"]))
-    XCTAssertNotEqual(representor, Representor(transitions:[:], representors:[:], attributes:[:], links:[:], metadata:[:]))
+    XCTAssertNotEqual(representor, Representor())
   }
 
   func testHashValue() {
-    let representor1 = Representor<HTTPTransition>(transitions:[:], representors:[:], attributes:[:], links:[:], metadata:[:])
-    let representor2 = Representor<HTTPTransition>(transitions:[:], representors:[:], attributes:[:], links:[:], metadata:[:])
+    let representor1 = Representor<HTTPTransition>()
+    let representor2 = Representor<HTTPTransition>()
     XCTAssertEqual(representor1.hashValue, representor2.hashValue)
   }
 }


### PR DESCRIPTION
This changes the default value for arrays and dictionaries to become optional with a default nil value. So that empty values can simply be omitted.

``` swift
let transition = HTTPTransition(uri:"/self/")
```

Instead of:

``` swift
let transition = HTTPTransition(uri:"/self/", attributes:[:], parameters:[:])
```

From @zdne's feedback on https://github.com/the-hypermedia-project/representor-swift/pull/9#issuecomment-72441884 
