### PR TITLE
[API Blueprint] Use action relation names and uriTemplate

### DIFF
--- a/Representor/HTTP/APIBlueprint/Blueprint.swift
+++ b/Representor/HTTP/APIBlueprint/Blueprint.swift
@@ -147,11 +147,19 @@ public struct Action {
   /// Array of URI parameters
   public let parameters:[Parameter]
 
-  public init(name:String, description:String?, method:String, parameters:[Parameter]) {
+  /// URI Template for the action, if it differs from the resource's URI
+  public let uriTemplate:String?
+
+  /// Link relation identifier of the action
+  public let relation:String?
+
+  public init(name:String, description:String?, method:String, parameters:[Parameter], uriTemplate:String? = nil, relation:String? = nil) {
     self.name = name
     self.description = description
     self.method = method
     self.parameters = parameters
+    self.uriTemplate = uriTemplate
+    self.relation = relation
   }
 }
 
@@ -193,10 +201,13 @@ func parseActions(source:[[String:AnyObject]]?) -> [Action] {
       let description = item["description"] as? String
       let method = item["method"] as? String
       let parameters = parseParameter(item["parameters"] as? [[String:AnyObject]])
+      let attributes = item["attributes"] as? [String:String]
+      let uriTemplate = attributes?["uriTemplate"]
+      let relation = attributes?["relation"]
 
       if let name = name {
         if let method = method {
-          return Action(name: name, description: description, method: method, parameters: parameters)
+          return Action(name: name, description: description, method: method, parameters: parameters, uriTemplate:uriTemplate, relation:relation)
         }
       }
 

--- a/Representor/HTTP/APIBlueprint/BlueprintTransition.swift
+++ b/Representor/HTTP/APIBlueprint/BlueprintTransition.swift
@@ -17,9 +17,23 @@ extension Array {
 
 extension Resource {
   func transition(actionName:String) -> HTTPTransition? {
-    let action = actions.filter{ action in action.name == actionName }.first
+    func filterAction(action:Action) -> Bool {
+      if let relationName = action.relation {
+        if relationName == actionName {
+          return true
+        }
+      }
+
+      if action.name == actionName {
+        return true
+      }
+
+      return false
+    }
+
+    let action = actions.filter(filterAction).first
     if let action = action {
-      return HTTPTransition(uri: uriTemplate) { builder in
+      return HTTPTransition(uri: action.uriTemplate ?? uriTemplate) { builder in
         builder.method = action.method
 
         let addParameter = { (parameter:Parameter) -> Void in

--- a/RepresentorTests/APIBlueprint/BlueprintTests.swift
+++ b/RepresentorTests/APIBlueprint/BlueprintTests.swift
@@ -65,7 +65,7 @@ class ActionTests : XCTestCase {
   var action:Action!
 
   override func setUp() {
-    action = Action(name: "Name", description: "Description", method: "GET", parameters: [])
+    action = Action(name: "Name", description: "Description", method: "GET", parameters: [], uriTemplate: "/users/{username}")
   }
 
   func testName() {
@@ -82,6 +82,14 @@ class ActionTests : XCTestCase {
 
   func testParameters() {
     XCTAssertEqual(action.parameters.count, 0)
+  }
+
+  func testRelation() {
+    XCTAssertNil(action.relation)
+  }
+
+  func testURITemplate() {
+    XCTAssertEqual(action.uriTemplate!, "/users/{username}")
   }
 }
 

--- a/RepresentorTests/APIBlueprint/BlueprintTransitionTests.swift
+++ b/RepresentorTests/APIBlueprint/BlueprintTransitionTests.swift
@@ -27,4 +27,38 @@ class BlueprintTransitionTests: XCTestCase {
     XCTAssertEqual(transitionParameter.value as String, "value")
     XCTAssertEqual(transitionParameter.defaultValue as String, "default")
   }
+
+  func testResourceWithURITemplateToTransitions() {
+    let parameter = Parameter(name: "name", description: nil, type: "string", required: true, defaultValue: "default", example: "value", values: nil)
+    let action = Action(name: "Create", description: nil, method: "PATCH", parameters: [parameter], uriTemplate: "/polls/2", relation: "update")
+    let resource = Resource(name: "Post", description: nil, uriTemplate: "/polls", parameters: [parameter], actions: [action])
+    let resourceGroup = ResourceGroup(name: "Name", description: nil, resources: [resource])
+    let blueprint = Blueprint(name: "Blueprint", description: nil, resourceGroups: [resourceGroup])
+
+    let transition = blueprint.transition("Post", action:"Create")!
+    let transitionParameter = transition.parameters["name"]!
+
+    XCTAssertEqual(transition.uri, "/polls/2")
+    XCTAssertEqual(transition.method, "PATCH")
+    XCTAssertEqual(Array(transition.parameters.keys), ["name"])
+    XCTAssertEqual(transitionParameter.value as String, "value")
+    XCTAssertEqual(transitionParameter.defaultValue as String, "default")
+  }
+
+  func testResourceWithRelationNameToTransitions() {
+    let parameter = Parameter(name: "name", description: nil, type: "string", required: true, defaultValue: "default", example: "value", values: nil)
+    let action = Action(name: "Create", description: nil, method: "PATCH", parameters: [parameter], uriTemplate: "/polls/2", relation: "update")
+    let resource = Resource(name: "Post", description: nil, uriTemplate: "/polls", parameters: [parameter], actions: [action])
+    let resourceGroup = ResourceGroup(name: "Name", description: nil, resources: [resource])
+    let blueprint = Blueprint(name: "Blueprint", description: nil, resourceGroups: [resourceGroup])
+
+    let transition = blueprint.transition("Post", action:"update")!
+    let transitionParameter = transition.parameters["name"]!
+
+    XCTAssertEqual(transition.uri, "/polls/2")
+    XCTAssertEqual(transition.method, "PATCH")
+    XCTAssertEqual(Array(transition.parameters.keys), ["name"])
+    XCTAssertEqual(transitionParameter.value as String, "value")
+    XCTAssertEqual(transitionParameter.defaultValue as String, "default")
+  }
 }


### PR DESCRIPTION
These changes make use of the relation name inside an action for looking up transitions. Along with using an actions uriTemplate over the resource's template if available.

Please don't merge until https://github.com/apiaryio/api-blueprint-ast/pull/29 is merged, this will need changes if anything changes in that pull-request.
