### PR TITLE
[Blueprint] Expose "content" (i.e, MSON elements) in the interface

### DIFF
--- a/Representor/HTTP/APIBlueprint/Blueprint.swift
+++ b/Representor/HTTP/APIBlueprint/Blueprint.swift
@@ -10,6 +10,8 @@ import Foundation
 
 // MARK: Models
 
+public typealias Metadata = (name:String, value:String)
+
 /// A structure representing an API Blueprint AST
 public struct Blueprint {
   /// Name of the API
@@ -21,13 +23,17 @@ public struct Blueprint {
   /// The collection of resource groups
   public let resourceGroups:[ResourceGroup]
 
+  public let metadata:[Metadata]
+
   public init(name:String, description:String?, resourceGroups:[ResourceGroup]) {
+    self.metadata = []
     self.name = name
     self.description = description
     self.resourceGroups = resourceGroups
   }
 
   public init(ast:[String:AnyObject]) {
+    metadata = parseMetadata(ast["metadata"] as? [[String:String]])
     name = ast["name"] as? String ?? ""
     description = ast["description"] as? String
     resourceGroups = parseBlueprintResourceGroups(ast)
@@ -227,6 +233,22 @@ func compactMap<C : CollectionType, T>(source: C, transform: (C.Generator.Elemen
   }
 
   return collection
+}
+
+func parseMetadata(source:[[String:String]]?) -> [Metadata] {
+  if let source = source {
+    return compactMap(source) { item in
+      if let name = item["name"] {
+        if let value = item["value"] {
+          return (name: name, value: value)
+        }
+      }
+
+      return nil
+    }
+  }
+
+  return []
 }
 
 func parseParameter(source:[[String:AnyObject]]?) -> [Parameter] {

--- a/Representor/HTTP/APIBlueprint/Blueprint.swift
+++ b/Representor/HTTP/APIBlueprint/Blueprint.swift
@@ -96,12 +96,15 @@ public struct Resource {
   /// Array of actions available on the resource each defining at least one complete HTTP transaction
   public let actions:[Action]
 
-  public init(name:String, description:String?, uriTemplate:String, parameters:[Parameter], actions:[Action]) {
+  public let content:[[String:AnyObject]]
+
+  public init(name:String, description:String?, uriTemplate:String, parameters:[Parameter], actions:[Action], content:[[String:AnyObject]]? = nil) {
     self.name = name
     self.description = description
     self.uriTemplate = uriTemplate
     self.actions = actions
     self.parameters = parameters
+    self.content = content ?? []
   }
 }
 
@@ -162,7 +165,7 @@ public struct Action {
   /// HTTP transaction examples for the relevant HTTP request method
   public let examples:[TransactionExample]
 
-  public init(name:String, description:String?, method:String, parameters:[Parameter], uriTemplate:String? = nil, relation:String? = nil, examples:[TransactionExample]? = nil) {
+  public init(name:String, description:String?, method:String, parameters:[Parameter], uriTemplate:String? = nil, relation:String? = nil, examples:[TransactionExample]? = nil, content:[[String:AnyObject]]? = nil) {
     self.name = name
     self.description = description
     self.method = method
@@ -212,11 +215,14 @@ public struct Payload {
   /// An entity body to be transferred with HTTP message represented by this payload
   public let body:NSData?
 
-  public init(name:String, description:String? = nil, headers:[Header]? = nil, body:NSData? = nil) {
+  public let content:[[String:AnyObject]]
+
+  public init(name:String, description:String? = nil, headers:[Header]? = nil, body:NSData? = nil, content:[[String:AnyObject]]? = nil) {
     self.name = name
     self.description = description
     self.headers = headers ?? []
     self.body = body
+    self.content = content ?? []
   }
 }
 
@@ -320,9 +326,10 @@ func parsePayloads(source:[[String:AnyObject]]?) -> [Payload] {
       let headers = parseHeaders(item["headers"] as? [[String:String]])
       let bodyString = item["body"] as? String
       let body = bodyString?.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: true)
+      let content = item["content"] as? [[String:AnyObject]]
 
       if let name = name {
-        return Payload(name: name, description: description, headers: headers, body: body)
+        return Payload(name: name, description: description, headers: headers, body: body, content: content)
       }
 
       return nil
@@ -356,10 +363,11 @@ func parseResources(source:[[String:AnyObject]]?) -> [Resource] {
       let uriTemplate = item["uriTemplate"] as? String
       let actions = parseActions(item["actions"] as? [[String:AnyObject]])
       let parameters = parseParameter(item["parameters"] as? [[String:AnyObject]])
+      let content = item["content"] as? [[String:AnyObject]]
 
       if let name = name {
         if let uriTemplate = uriTemplate {
-          return Resource(name: name, description: description, uriTemplate: uriTemplate, parameters: parameters, actions: actions)
+          return Resource(name: name, description: description, uriTemplate: uriTemplate, parameters: parameters, actions: actions, content: content)
         }
       }
 

--- a/RepresentorTests/APIBlueprint/BlueprintTests.swift
+++ b/RepresentorTests/APIBlueprint/BlueprintTests.swift
@@ -176,72 +176,40 @@ class BlueprintTests : XCTestCase {
     let bundle = NSBundle(forClass:object_getClass(self))
     let blueprint = Blueprint(named:"blueprint.json", bundle:bundle)!
 
-    XCTAssertEqual(blueprint.name, "Requests API")
-    XCTAssertEqual(blueprint.description!, "Following the [Responses](5.%20Responses.md) example, this API will show you how to define multiple requests and what data these requests can bear. Let's demonstrate multiple requests on a trivial example of content negotiation.\n\n## API Blueprint\n\n+ [Previous: Responses](5.%20Responses.md)\n\n+ [This: Raw API Blueprint](https://raw.github.com/apiaryio/api-blueprint/master/examples/6.%20Requests.md)\n\n+ [Next: Parameters](7.%20Parameters.md)\n\n")
+    XCTAssertEqual(blueprint.name, "Polls")
+    XCTAssertEqual(blueprint.description!, "Polls is a simple web service that allows consumers to view polls and vote in them.\n\n")
 
     let resourceGroups = blueprint.resourceGroups
-    let resourceGroup = resourceGroups[0]
-    XCTAssertEqual(resourceGroups.count, 1)
-    XCTAssertEqual(resourceGroup.name, "Messages")
-    XCTAssertEqual(resourceGroup.description!, "Group of all messages-related resources.\n\n")
+    let resourceGroup = resourceGroups[1]
+    XCTAssertEqual(resourceGroups.count, 2)
+    XCTAssertEqual(resourceGroup.name, "Question")
+    XCTAssertEqual(resourceGroup.description!, "Resource related to questions in the API.\n\n")
 
     let resource = resourceGroup.resources[0]
-    XCTAssertEqual(resourceGroup.resources.count, 1)
-    XCTAssertEqual(resource.name, "My Message")
-    XCTAssertEqual(resource.description!, "")
-    XCTAssertEqual(resource.uriTemplate, "/message")
+    XCTAssertEqual(resourceGroup.resources.count, 3)
+    XCTAssertEqual(resource.name, "Question")
+    XCTAssertTrue(resource.description!.hasPrefix("A Question object has the following attributes."))
+    XCTAssertEqual(resource.uriTemplate, "/questions/{question_id}")
 
     let retrieveAction = resource.actions[0]
-    let updateAction = resource.actions[1]
-    XCTAssertEqual(resource.actions.count, 2)
+    XCTAssertEqual(resource.actions.count, 1)
 
-    XCTAssertEqual(retrieveAction.name, "Retrieve a Message")
-    XCTAssertEqual(retrieveAction.description!, "In API Blueprint requests can hold exactly the same kind of information and can be described by exactly the same structure as responses, only with different signature – using the `Request` keyword. The string that follows after the `Request` keyword is a request identifier. Again, using an explanatory and simple naming is the best way to go. \n\n")
+    XCTAssertEqual(retrieveAction.name, "View a question detail")
     XCTAssertEqual(retrieveAction.method, "GET")
 
-    XCTAssertEqual(retrieveAction.examples.count, 2)
+    XCTAssertEqual(retrieveAction.examples.count, 1)
 
     let example1 = retrieveAction.examples[0]
     XCTAssertEqual(example1.name, "")
     XCTAssertEqual(example1.description!, "")
-    XCTAssertEqual(example1.requests.count, 1)
+    XCTAssertEqual(example1.requests.count, 0)
     XCTAssertEqual(example1.responses.count, 1)
-
-    let requestPayload = example1.requests[0]
-    XCTAssertEqual(requestPayload.name, "Plain Text Message")
-    XCTAssertEqual(requestPayload.description!, "")
-    XCTAssertEqual(requestPayload.headers.count, 1)
-    XCTAssertEqual(requestPayload.headers[0].name, "Accept")
-    XCTAssertEqual(requestPayload.headers[0].value, "text/plain")
 
     let responsePayload = example1.responses[0]
     XCTAssertEqual(responsePayload.name, "200")
     XCTAssertEqual(responsePayload.description!, "")
-    XCTAssertEqual(responsePayload.headers.count, 2)
+    XCTAssertEqual(responsePayload.headers.count, 1)
     XCTAssertEqual(responsePayload.headers[0].name, "Content-Type")
-    XCTAssertEqual(responsePayload.headers[0].value, "text/plain")
-    XCTAssertEqual(responsePayload.headers[1].name, "X-My-Message-Header")
-    XCTAssertEqual(responsePayload.headers[1].value, "42")
-    let body = "Hello World!\n".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: true)!
-    XCTAssertEqual(responsePayload.body!, body)
-
-    let example2 = retrieveAction.examples[1]
-    XCTAssertEqual(example2.name, "")
-    XCTAssertEqual(example2.description!, "")
-    XCTAssertEqual(example2.requests.count, 1)
-    XCTAssertEqual(example2.responses.count, 1)
-
-    let parameter = retrieveAction.parameters[0]
-    XCTAssertEqual(parameter.name, "id")
-    XCTAssertEqual(parameter.description!, "An unique identifier of the message.")
-    XCTAssertEqual(parameter.type!, "number")
-    XCTAssertTrue(parameter.required)
-    XCTAssertEqual(parameter.defaultValue!, "")
-    XCTAssertEqual(parameter.example!, "1")
-    XCTAssertEqual(parameter.values!, [])
-
-    XCTAssertEqual(updateAction.name, "Update a Message")
-    XCTAssertEqual(updateAction.description!, "")
-    XCTAssertEqual(updateAction.method, "PUT")
+    XCTAssertEqual(responsePayload.headers[0].value, "application/json")
   }
 }

--- a/RepresentorTests/APIBlueprint/BlueprintTests.swift
+++ b/RepresentorTests/APIBlueprint/BlueprintTests.swift
@@ -210,8 +210,17 @@ class BlueprintTests : XCTestCase {
     XCTAssertEqual(responsePayload.headers.count, 1)
     XCTAssertEqual(responsePayload.headers[0].name, "Content-Type")
     XCTAssertEqual(responsePayload.headers[0].value, "application/json")
-  }
 
+    // Test the choices are parsed in resources
+    XCTAssertEqual(resource.content.count, 1)
+
+    // Test the choices are parsed in payloads
+    let questionsResource = resourceGroup.resources[2]
+    let questionsAction = questionsResource.actions[0]
+    let questionsResponseExample = questionsAction.examples[0].responses[0]
+    XCTAssertEqual(questionsResource.name, "Questions Collection")
+    XCTAssertEqual(questionsResponseExample.content.count, 1)
+  }
 
   func testParsingMetadataFromAST() {
     let bundle = NSBundle(forClass:object_getClass(self))

--- a/RepresentorTests/APIBlueprint/BlueprintTests.swift
+++ b/RepresentorTests/APIBlueprint/BlueprintTests.swift
@@ -212,4 +212,19 @@ class BlueprintTests : XCTestCase {
     XCTAssertEqual(responsePayload.headers[0].name, "Content-Type")
     XCTAssertEqual(responsePayload.headers[0].value, "application/json")
   }
+
+
+  func testParsingMetadataFromAST() {
+    let bundle = NSBundle(forClass:object_getClass(self))
+    let blueprint = Blueprint(named:"blueprint.json", bundle:bundle)!
+
+    let format = blueprint.metadata[0]
+    let host = blueprint.metadata[1]
+
+    XCTAssertEqual(format.name, "FORMAT")
+    XCTAssertEqual(format.value, "1A")
+
+    XCTAssertEqual(host.name, "HOST")
+    XCTAssertEqual(host.value, "https://polls.apiblueprint.org/")
+  }
 }

--- a/RepresentorTests/APIBlueprint/BlueprintTests.swift
+++ b/RepresentorTests/APIBlueprint/BlueprintTests.swift
@@ -177,24 +177,23 @@ class BlueprintTests : XCTestCase {
     let blueprint = Blueprint(named:"blueprint.json", bundle:bundle)!
 
     XCTAssertEqual(blueprint.name, "Polls")
-    XCTAssertEqual(blueprint.description!, "Polls is a simple web service that allows consumers to view polls and vote in them.\n\n")
+    XCTAssertTrue(blueprint.description!.hasPrefix("Polls is a simple API allowing consumers to view polls and vote in them."))
 
     let resourceGroups = blueprint.resourceGroups
     let resourceGroup = resourceGroups[1]
     XCTAssertEqual(resourceGroups.count, 2)
     XCTAssertEqual(resourceGroup.name, "Question")
-    XCTAssertEqual(resourceGroup.description!, "Resource related to questions in the API.\n\n")
+    XCTAssertTrue(resourceGroup.description!.hasPrefix("Resources related to questions in the API."))
 
     let resource = resourceGroup.resources[0]
     XCTAssertEqual(resourceGroup.resources.count, 3)
     XCTAssertEqual(resource.name, "Question")
-    XCTAssertTrue(resource.description!.hasPrefix("A Question object has the following attributes."))
     XCTAssertEqual(resource.uriTemplate, "/questions/{question_id}")
 
     let retrieveAction = resource.actions[0]
     XCTAssertEqual(resource.actions.count, 1)
 
-    XCTAssertEqual(retrieveAction.name, "View a question detail")
+    XCTAssertEqual(retrieveAction.name, "View a Questions Detail")
     XCTAssertEqual(retrieveAction.method, "GET")
 
     XCTAssertEqual(retrieveAction.examples.count, 1)

--- a/RepresentorTests/Fixtures/blueprint.json
+++ b/RepresentorTests/Fixtures/blueprint.json
@@ -11,7 +11,7 @@
     }
   ],
   "name": "Polls",
-  "description": "Polls is a simple web service that allows consumers to view polls and vote in them.\n\n",
+  "description": "Polls is a simple API allowing consumers to view polls and vote in them.\n\n",
   "element": "category",
   "resourceGroups": [
     {
@@ -21,7 +21,7 @@
         {
           "element": "resource",
           "name": "Polls API Root",
-          "description": "This resource does not have any attributes. Instead it offers the initial API affordances in the form of the links in the JSON body.\n\nIt is recommend to follow the “url” link values or Link headers to get to resources instead of constructing your own URLs to keep your client decoupled from implementation details.\n\n",
+          "description": "This resource does not have any attributes. Instead it offers the initial\nAPI affordances in the form of the links in the JSON body.\n\nIt is recommend to follow the “url” link values,\n[Link](https://tools.ietf.org/html/rfc5988) or Location headers where\napplicable to retrieve resources. Instead of constructing your own URLs,\nto keep your client decoupled from implementation details.\n\n",
           "uriTemplate": "/",
           "model": {},
           "parameters": [],
@@ -74,12 +74,12 @@
     },
     {
       "name": "Question",
-      "description": "Resource related to questions in the API.\n\n",
+      "description": "Resources related to questions in the API.\n\n",
       "resources": [
         {
           "element": "resource",
           "name": "Question",
-          "description": "A Question object has the following attributes.\n\n- question\n\n- published_at\n\n- url\n\n- choices (an array of Choice objects).\n\n",
+          "description": "",
           "uriTemplate": "/questions/{question_id}",
           "model": {},
           "parameters": [
@@ -95,7 +95,7 @@
           ],
           "actions": [
             {
-              "name": "View a question detail",
+              "name": "View a Questions Detail",
               "description": "",
               "method": "GET",
               "parameters": [],
@@ -136,7 +136,133 @@
               ]
             }
           ],
-          "content": []
+          "content": [
+            {
+              "element": "dataStructure",
+              "name": {
+                "literal": "Question",
+                "variable": false
+              },
+              "typeDefinition": {
+                "typeSpecification": {
+                  "name": null,
+                  "nestedTypes": []
+                },
+                "attributes": []
+              },
+              "sections": [
+                {
+                  "class": "memberType",
+                  "content": [
+                    {
+                      "content": {
+                        "name": {
+                          "literal": "question"
+                        },
+                        "description": "",
+                        "valueDefinition": {
+                          "values": [
+                            {
+                              "literal": "Favourite programming language?",
+                              "variable": false
+                            }
+                          ],
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": "string",
+                              "nestedTypes": []
+                            },
+                            "attributes": [
+                              "required"
+                            ]
+                          }
+                        },
+                        "sections": []
+                      },
+                      "class": "property"
+                    },
+                    {
+                      "content": {
+                        "name": {
+                          "literal": "published_at"
+                        },
+                        "description": "11-11T08:40:51.620Z (string) - An ISO8601 date when the question was published",
+                        "valueDefinition": {
+                          "values": [
+                            {
+                              "literal": "2014",
+                              "variable": false
+                            }
+                          ],
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": null,
+                              "nestedTypes": []
+                            },
+                            "attributes": []
+                          }
+                        },
+                        "sections": []
+                      },
+                      "class": "property"
+                    },
+                    {
+                      "content": {
+                        "name": {
+                          "literal": "choices"
+                        },
+                        "description": "An array of Choice objects",
+                        "valueDefinition": {
+                          "values": [],
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": "array",
+                              "nestedTypes": [
+                                {
+                                  "literal": "Choice",
+                                  "variable": false
+                                }
+                              ]
+                            },
+                            "attributes": [
+                              "required"
+                            ]
+                          }
+                        },
+                        "sections": []
+                      },
+                      "class": "property"
+                    },
+                    {
+                      "content": {
+                        "name": {
+                          "literal": "url"
+                        },
+                        "description": "",
+                        "valueDefinition": {
+                          "values": [
+                            {
+                              "literal": "/questions/1",
+                              "variable": false
+                            }
+                          ],
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": "string",
+                              "nestedTypes": []
+                            },
+                            "attributes": []
+                          }
+                        },
+                        "sections": []
+                      },
+                      "class": "property"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
           "element": "resource",
@@ -186,33 +312,101 @@
                       "description": "",
                       "headers": [
                         {
-                          "name": "Content-Type",
-                          "value": "application/json"
+                          "name": "Location",
+                          "value": "/questions/1"
                         }
                       ],
-                      "body": "{\n    \"url\": \"/questions/1/choices/1\",\n    \"votes\": 1,\n    \"choice\": \"Swift\"\n}\n",
+                      "body": "",
                       "schema": "",
-                      "content": [
-                        {
-                          "element": "asset",
-                          "attributes": {
-                            "role": "bodyExample"
-                          },
-                          "content": "{\n    \"url\": \"/questions/1/choices/1\",\n    \"votes\": 1,\n    \"choice\": \"Swift\"\n}\n"
-                        }
-                      ]
+                      "content": []
                     }
                   ]
                 }
               ]
             }
           ],
-          "content": []
+          "content": [
+            {
+              "element": "dataStructure",
+              "name": {
+                "literal": "Choice",
+                "variable": false
+              },
+              "typeDefinition": {
+                "typeSpecification": {
+                  "name": null,
+                  "nestedTypes": []
+                },
+                "attributes": []
+              },
+              "sections": [
+                {
+                  "class": "memberType",
+                  "content": [
+                    {
+                      "content": {
+                        "name": {
+                          "literal": "choice"
+                        },
+                        "description": "",
+                        "valueDefinition": {
+                          "values": [
+                            {
+                              "literal": "Swift",
+                              "variable": false
+                            }
+                          ],
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": "string",
+                              "nestedTypes": []
+                            },
+                            "attributes": [
+                              "required"
+                            ]
+                          }
+                        },
+                        "sections": []
+                      },
+                      "class": "property"
+                    },
+                    {
+                      "content": {
+                        "name": {
+                          "literal": "votes"
+                        },
+                        "description": "",
+                        "valueDefinition": {
+                          "values": [
+                            {
+                              "literal": "0",
+                              "variable": false
+                            }
+                          ],
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": "number",
+                              "nestedTypes": []
+                            },
+                            "attributes": [
+                              "required"
+                            ]
+                          }
+                        },
+                        "sections": []
+                      },
+                      "class": "property"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
           "element": "resource",
-          "name": "Questions collection",
-          "description": "Again, instead of constructing the URLs for the next page. It is **highly** recommended that you follow the `next` link header in the response.\n\n",
+          "name": "Questions Collection",
+          "description": "",
           "uriTemplate": "/questions{?page}",
           "model": {},
           "parameters": [
@@ -228,7 +422,7 @@
           ],
           "actions": [
             {
-              "name": "List all questions",
+              "name": "List All Questions",
               "description": "",
               "method": "GET",
               "parameters": [],
@@ -256,15 +450,25 @@
                           "value": "</questions?page=2>; rel=\"next\""
                         }
                       ],
-                      "body": "[\n    {\n        \"question\": \"Favourite programming language?\",\n        \"published_at\": \"2014-11-11T08:40:51.620Z\",\n        \"url\": \"/questions/1\",\n        \"choices\": [\n            {\n                \"choice\": \"Swift\",\n                \"url\": \"/questions/1/choices/1\",\n                \"votes\": 2048\n            }, {\n                \"choice\": \"Python\",\n                \"url\": \"/questions/1/choices/2\",\n                \"votes\": 1024\n            }, {\n                \"choice\": \"Objective-C\",\n                \"url\": \"/questions/1/choices/3\",\n                \"votes\": 512\n            }, {\n                \"choice\": \"Ruby\",\n                \"url\": \"/questions/1/choices/4\",\n                \"votes\": 256\n            }\n        ]\n    }\n]\n",
+                      "body": "",
                       "schema": "",
                       "content": [
                         {
-                          "element": "asset",
-                          "attributes": {
-                            "role": "bodyExample"
+                          "element": "dataStructure",
+                          "name": null,
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": "array",
+                              "nestedTypes": [
+                                {
+                                  "literal": "Question",
+                                  "variable": false
+                                }
+                              ]
+                            },
+                            "attributes": []
                           },
-                          "content": "[\n    {\n        \"question\": \"Favourite programming language?\",\n        \"published_at\": \"2014-11-11T08:40:51.620Z\",\n        \"url\": \"/questions/1\",\n        \"choices\": [\n            {\n                \"choice\": \"Swift\",\n                \"url\": \"/questions/1/choices/1\",\n                \"votes\": 2048\n            }, {\n                \"choice\": \"Python\",\n                \"url\": \"/questions/1/choices/2\",\n                \"votes\": 1024\n            }, {\n                \"choice\": \"Objective-C\",\n                \"url\": \"/questions/1/choices/3\",\n                \"votes\": 512\n            }, {\n                \"choice\": \"Ruby\",\n                \"url\": \"/questions/1/choices/4\",\n                \"votes\": 256\n            }\n        ]\n    }\n]\n"
+                          "sections": []
                         }
                       ]
                     }
@@ -273,8 +477,8 @@
               ]
             },
             {
-              "name": "Create a new question",
-              "description": "You can create your own question using this action. It takes a JSON dictionary containing a question and a collection of answers in the form of choices.\n\n- question (string) - The question\n\n- choices (array[string]) - A collection of choices.\n\n",
+              "name": "Create a New Question",
+              "description": "You may create your own question using this action. It takes a JSON\nobject containing a question and a collection of answers in the\nform of choices.\n\n+ question (string) - The question\n\n+ choices (array[string]) - A collection of choices.\n\n",
               "method": "POST",
               "parameters": [],
               "attributes": {
@@ -352,7 +556,7 @@
         {
           "element": "resource",
           "name": "Polls API Root",
-          "description": "This resource does not have any attributes. Instead it offers the initial API affordances in the form of the links in the JSON body.\n\nIt is recommend to follow the “url” link values or Link headers to get to resources instead of constructing your own URLs to keep your client decoupled from implementation details.\n\n",
+          "description": "This resource does not have any attributes. Instead it offers the initial\nAPI affordances in the form of the links in the JSON body.\n\nIt is recommend to follow the “url” link values,\n[Link](https://tools.ietf.org/html/rfc5988) or Location headers where\napplicable to retrieve resources. Instead of constructing your own URLs,\nto keep your client decoupled from implementation details.\n\n",
           "uriTemplate": "/",
           "model": {},
           "parameters": [],
@@ -411,12 +615,12 @@
       "content": [
         {
           "element": "copy",
-          "content": "Resource related to questions in the API.\n\n"
+          "content": "Resources related to questions in the API.\n\n"
         },
         {
           "element": "resource",
           "name": "Question",
-          "description": "A Question object has the following attributes.\n\n- question\n\n- published_at\n\n- url\n\n- choices (an array of Choice objects).\n\n",
+          "description": "",
           "uriTemplate": "/questions/{question_id}",
           "model": {},
           "parameters": [
@@ -432,7 +636,7 @@
           ],
           "actions": [
             {
-              "name": "View a question detail",
+              "name": "View a Questions Detail",
               "description": "",
               "method": "GET",
               "parameters": [],
@@ -473,7 +677,133 @@
               ]
             }
           ],
-          "content": []
+          "content": [
+            {
+              "element": "dataStructure",
+              "name": {
+                "literal": "Question",
+                "variable": false
+              },
+              "typeDefinition": {
+                "typeSpecification": {
+                  "name": null,
+                  "nestedTypes": []
+                },
+                "attributes": []
+              },
+              "sections": [
+                {
+                  "class": "memberType",
+                  "content": [
+                    {
+                      "content": {
+                        "name": {
+                          "literal": "question"
+                        },
+                        "description": "",
+                        "valueDefinition": {
+                          "values": [
+                            {
+                              "literal": "Favourite programming language?",
+                              "variable": false
+                            }
+                          ],
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": "string",
+                              "nestedTypes": []
+                            },
+                            "attributes": [
+                              "required"
+                            ]
+                          }
+                        },
+                        "sections": []
+                      },
+                      "class": "property"
+                    },
+                    {
+                      "content": {
+                        "name": {
+                          "literal": "published_at"
+                        },
+                        "description": "11-11T08:40:51.620Z (string) - An ISO8601 date when the question was published",
+                        "valueDefinition": {
+                          "values": [
+                            {
+                              "literal": "2014",
+                              "variable": false
+                            }
+                          ],
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": null,
+                              "nestedTypes": []
+                            },
+                            "attributes": []
+                          }
+                        },
+                        "sections": []
+                      },
+                      "class": "property"
+                    },
+                    {
+                      "content": {
+                        "name": {
+                          "literal": "choices"
+                        },
+                        "description": "An array of Choice objects",
+                        "valueDefinition": {
+                          "values": [],
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": "array",
+                              "nestedTypes": [
+                                {
+                                  "literal": "Choice",
+                                  "variable": false
+                                }
+                              ]
+                            },
+                            "attributes": [
+                              "required"
+                            ]
+                          }
+                        },
+                        "sections": []
+                      },
+                      "class": "property"
+                    },
+                    {
+                      "content": {
+                        "name": {
+                          "literal": "url"
+                        },
+                        "description": "",
+                        "valueDefinition": {
+                          "values": [
+                            {
+                              "literal": "/questions/1",
+                              "variable": false
+                            }
+                          ],
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": "string",
+                              "nestedTypes": []
+                            },
+                            "attributes": []
+                          }
+                        },
+                        "sections": []
+                      },
+                      "class": "property"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
           "element": "resource",
@@ -523,33 +853,101 @@
                       "description": "",
                       "headers": [
                         {
-                          "name": "Content-Type",
-                          "value": "application/json"
+                          "name": "Location",
+                          "value": "/questions/1"
                         }
                       ],
-                      "body": "{\n    \"url\": \"/questions/1/choices/1\",\n    \"votes\": 1,\n    \"choice\": \"Swift\"\n}\n",
+                      "body": "",
                       "schema": "",
-                      "content": [
-                        {
-                          "element": "asset",
-                          "attributes": {
-                            "role": "bodyExample"
-                          },
-                          "content": "{\n    \"url\": \"/questions/1/choices/1\",\n    \"votes\": 1,\n    \"choice\": \"Swift\"\n}\n"
-                        }
-                      ]
+                      "content": []
                     }
                   ]
                 }
               ]
             }
           ],
-          "content": []
+          "content": [
+            {
+              "element": "dataStructure",
+              "name": {
+                "literal": "Choice",
+                "variable": false
+              },
+              "typeDefinition": {
+                "typeSpecification": {
+                  "name": null,
+                  "nestedTypes": []
+                },
+                "attributes": []
+              },
+              "sections": [
+                {
+                  "class": "memberType",
+                  "content": [
+                    {
+                      "content": {
+                        "name": {
+                          "literal": "choice"
+                        },
+                        "description": "",
+                        "valueDefinition": {
+                          "values": [
+                            {
+                              "literal": "Swift",
+                              "variable": false
+                            }
+                          ],
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": "string",
+                              "nestedTypes": []
+                            },
+                            "attributes": [
+                              "required"
+                            ]
+                          }
+                        },
+                        "sections": []
+                      },
+                      "class": "property"
+                    },
+                    {
+                      "content": {
+                        "name": {
+                          "literal": "votes"
+                        },
+                        "description": "",
+                        "valueDefinition": {
+                          "values": [
+                            {
+                              "literal": "0",
+                              "variable": false
+                            }
+                          ],
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": "number",
+                              "nestedTypes": []
+                            },
+                            "attributes": [
+                              "required"
+                            ]
+                          }
+                        },
+                        "sections": []
+                      },
+                      "class": "property"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
           "element": "resource",
-          "name": "Questions collection",
-          "description": "Again, instead of constructing the URLs for the next page. It is **highly** recommended that you follow the `next` link header in the response.\n\n",
+          "name": "Questions Collection",
+          "description": "",
           "uriTemplate": "/questions{?page}",
           "model": {},
           "parameters": [
@@ -565,7 +963,7 @@
           ],
           "actions": [
             {
-              "name": "List all questions",
+              "name": "List All Questions",
               "description": "",
               "method": "GET",
               "parameters": [],
@@ -593,15 +991,25 @@
                           "value": "</questions?page=2>; rel=\"next\""
                         }
                       ],
-                      "body": "[\n    {\n        \"question\": \"Favourite programming language?\",\n        \"published_at\": \"2014-11-11T08:40:51.620Z\",\n        \"url\": \"/questions/1\",\n        \"choices\": [\n            {\n                \"choice\": \"Swift\",\n                \"url\": \"/questions/1/choices/1\",\n                \"votes\": 2048\n            }, {\n                \"choice\": \"Python\",\n                \"url\": \"/questions/1/choices/2\",\n                \"votes\": 1024\n            }, {\n                \"choice\": \"Objective-C\",\n                \"url\": \"/questions/1/choices/3\",\n                \"votes\": 512\n            }, {\n                \"choice\": \"Ruby\",\n                \"url\": \"/questions/1/choices/4\",\n                \"votes\": 256\n            }\n        ]\n    }\n]\n",
+                      "body": "",
                       "schema": "",
                       "content": [
                         {
-                          "element": "asset",
-                          "attributes": {
-                            "role": "bodyExample"
+                          "element": "dataStructure",
+                          "name": null,
+                          "typeDefinition": {
+                            "typeSpecification": {
+                              "name": "array",
+                              "nestedTypes": [
+                                {
+                                  "literal": "Question",
+                                  "variable": false
+                                }
+                              ]
+                            },
+                            "attributes": []
                           },
-                          "content": "[\n    {\n        \"question\": \"Favourite programming language?\",\n        \"published_at\": \"2014-11-11T08:40:51.620Z\",\n        \"url\": \"/questions/1\",\n        \"choices\": [\n            {\n                \"choice\": \"Swift\",\n                \"url\": \"/questions/1/choices/1\",\n                \"votes\": 2048\n            }, {\n                \"choice\": \"Python\",\n                \"url\": \"/questions/1/choices/2\",\n                \"votes\": 1024\n            }, {\n                \"choice\": \"Objective-C\",\n                \"url\": \"/questions/1/choices/3\",\n                \"votes\": 512\n            }, {\n                \"choice\": \"Ruby\",\n                \"url\": \"/questions/1/choices/4\",\n                \"votes\": 256\n            }\n        ]\n    }\n]\n"
+                          "sections": []
                         }
                       ]
                     }
@@ -610,8 +1018,8 @@
               ]
             },
             {
-              "name": "Create a new question",
-              "description": "You can create your own question using this action. It takes a JSON dictionary containing a question and a collection of answers in the form of choices.\n\n- question (string) - The question\n\n- choices (array[string]) - A collection of choices.\n\n",
+              "name": "Create a New Question",
+              "description": "You may create your own question using this action. It takes a JSON\nobject containing a question and a collection of answers in the\nform of choices.\n\n+ question (string) - The question\n\n+ choices (array[string]) - A collection of choices.\n\n",
               "method": "POST",
               "parameters": [],
               "attributes": {

--- a/RepresentorTests/Fixtures/blueprint.json
+++ b/RepresentorTests/Fixtures/blueprint.json
@@ -1,58 +1,46 @@
 {
-  "_version": "2.1",
+  "_version": "3.0",
   "metadata": [
     {
       "name": "FORMAT",
       "value": "1A"
+    },
+    {
+      "name": "HOST",
+      "value": "https://polls.apiblueprint.org/"
     }
   ],
-  "name": "Requests API",
-  "description": "Following the [Responses](5.%20Responses.md) example, this API will show you how to define multiple requests and what data these requests can bear. Let's demonstrate multiple requests on a trivial example of content negotiation.\n\n## API Blueprint\n\n+ [Previous: Responses](5.%20Responses.md)\n\n+ [This: Raw API Blueprint](https://raw.github.com/apiaryio/api-blueprint/master/examples/6.%20Requests.md)\n\n+ [Next: Parameters](7.%20Parameters.md)\n\n",
+  "name": "Polls",
+  "description": "Polls is a simple web service that allows consumers to view polls and vote in them.\n\n",
+  "element": "category",
   "resourceGroups": [
     {
-      "name": "Messages",
-      "description": "Group of all messages-related resources.\n\n",
+      "name": "",
+      "description": "",
       "resources": [
         {
-          "name": "My Message",
-          "description": "",
-          "uriTemplate": "/message",
+          "element": "resource",
+          "name": "Polls API Root",
+          "description": "This resource does not have any attributes. Instead it offers the initial API affordances in the form of the links in the JSON body.\n\nIt is recommend to follow the “url” link values or Link headers to get to resources instead of constructing your own URLs to keep your client decoupled from implementation details.\n\n",
+          "uriTemplate": "/",
           "model": {},
           "parameters": [],
           "actions": [
             {
-              "name": "Retrieve a Message",
-              "description": "In API Blueprint requests can hold exactly the same kind of information and can be described by exactly the same structure as responses, only with different signature – using the `Request` keyword. The string that follows after the `Request` keyword is a request identifier. Again, using an explanatory and simple naming is the best way to go. \n\n",
+              "name": "Retrieve the Entry Point",
+              "description": "",
               "method": "GET",
-              "parameters": [
-                {
-                  "name": "id",
-                  "description": "An unique identifier of the message.",
-                  "type": "number",
-                  "required": true,
-                  "default": "",
-                  "example": "1",
-                  "values": []
-                }
-              ],
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
               "examples": [
                 {
                   "name": "",
                   "description": "",
-                  "requests": [
-                    {
-                      "name": "Plain Text Message",
-                      "description": "",
-                      "headers": [
-                        {
-                          "name": "Accept",
-                          "value": "text/plain"
-                        }
-                      ],
-                      "body": "",
-                      "schema": ""
-                    }
-                  ],
+                  "requests": [],
                   "responses": [
                     {
                       "name": "200",
@@ -60,35 +48,200 @@
                       "headers": [
                         {
                           "name": "Content-Type",
-                          "value": "text/plain"
-                        },
-                        {
-                          "name": "X-My-Message-Header",
-                          "value": "42"
+                          "value": "application/json"
                         }
                       ],
-                      "body": "Hello World!\n",
-                      "schema": ""
+                      "body": "{\n    \"questions_url\": \"/questions\"\n}\n",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "{\n    \"questions_url\": \"/questions\"\n}\n"
+                        }
+                      ]
                     }
                   ]
-                },
+                }
+              ]
+            }
+          ],
+          "content": []
+        }
+      ]
+    },
+    {
+      "name": "Question",
+      "description": "Resource related to questions in the API.\n\n",
+      "resources": [
+        {
+          "element": "resource",
+          "name": "Question",
+          "description": "A Question object has the following attributes.\n\n- question\n\n- published_at\n\n- url\n\n- choices (an array of Choice objects).\n\n",
+          "uriTemplate": "/questions/{question_id}",
+          "model": {},
+          "parameters": [
+            {
+              "name": "question_id",
+              "description": "ID of the Question in form of an integer",
+              "type": "number",
+              "required": true,
+              "default": "",
+              "example": "1",
+              "values": []
+            }
+          ],
+          "actions": [
+            {
+              "name": "View a question detail",
+              "description": "",
+              "method": "GET",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
                 {
                   "name": "",
                   "description": "",
-                  "requests": [
+                  "requests": [],
+                  "responses": [
                     {
-                      "name": "JSON Message",
+                      "name": "200",
                       "description": "",
                       "headers": [
                         {
-                          "name": "Accept",
+                          "name": "Content-Type",
                           "value": "application/json"
                         }
                       ],
-                      "body": "",
-                      "schema": ""
+                      "body": "        {\n            \"question\": \"Favourite programming language?\",\n            \"published_at\": \"2014-11-11T08:40:51.620Z\",\n            \"url\": \"/questions/1\",\n            \"choices\": [\n                {\n                    \"choice\": \"Swift\",\n                    \"url\": \"/questions/1/choices/1\",\n                    \"votes\": 2048\n                }, {\n                    \"choice\": \"Python\",\n                    \"url\": \"/questions/1/choices/2\",\n                    \"votes\": 1024\n                }, {\n                    \"choice\": \"Objective-C\",\n                    \"url\": \"/questions/1/choices/3\",\n                    \"votes\": 512\n                }, {\n                    \"choice\": \"Ruby\",\n                    \"url\": \"/questions/1/choices/4\",\n                    \"votes\": 256\n                }\n            ]\n        }\n",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "        {\n            \"question\": \"Favourite programming language?\",\n            \"published_at\": \"2014-11-11T08:40:51.620Z\",\n            \"url\": \"/questions/1\",\n            \"choices\": [\n                {\n                    \"choice\": \"Swift\",\n                    \"url\": \"/questions/1/choices/1\",\n                    \"votes\": 2048\n                }, {\n                    \"choice\": \"Python\",\n                    \"url\": \"/questions/1/choices/2\",\n                    \"votes\": 1024\n                }, {\n                    \"choice\": \"Objective-C\",\n                    \"url\": \"/questions/1/choices/3\",\n                    \"votes\": 512\n                }, {\n                    \"choice\": \"Ruby\",\n                    \"url\": \"/questions/1/choices/4\",\n                    \"votes\": 256\n                }\n            ]\n        }\n"
+                        }
+                      ]
                     }
-                  ],
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": []
+        },
+        {
+          "element": "resource",
+          "name": "Choice",
+          "description": "",
+          "uriTemplate": "/questions/{question_id}/choices/{choice_id}",
+          "model": {},
+          "parameters": [
+            {
+              "name": "question_id",
+              "description": "ID of the Question in form of an integer",
+              "type": "number",
+              "required": true,
+              "default": "",
+              "example": "1",
+              "values": []
+            },
+            {
+              "name": "choice_id",
+              "description": "ID of the Choice in form of an integer",
+              "type": "number",
+              "required": true,
+              "default": "",
+              "example": "1",
+              "values": []
+            }
+          ],
+          "actions": [
+            {
+              "name": "Vote on a Choice",
+              "description": "This action allows you to vote on a question's choice.\n\n",
+              "method": "POST",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [],
+                  "responses": [
+                    {
+                      "name": "201",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json"
+                        }
+                      ],
+                      "body": "{\n    \"url\": \"/questions/1/choices/1\",\n    \"votes\": 1,\n    \"choice\": \"Swift\"\n}\n",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "{\n    \"url\": \"/questions/1/choices/1\",\n    \"votes\": 1,\n    \"choice\": \"Swift\"\n}\n"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": []
+        },
+        {
+          "element": "resource",
+          "name": "Questions collection",
+          "description": "Again, instead of constructing the URLs for the next page. It is **highly** recommended that you follow the `next` link header in the response.\n\n",
+          "uriTemplate": "/questions{?page}",
+          "model": {},
+          "parameters": [
+            {
+              "name": "page",
+              "description": "The page of questions to return",
+              "type": "number",
+              "required": false,
+              "default": "",
+              "example": "1",
+              "values": []
+            }
+          ],
+          "actions": [
+            {
+              "name": "List all questions",
+              "description": "",
+              "method": "GET",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [],
                   "responses": [
                     {
                       "name": "200",
@@ -99,41 +252,43 @@
                           "value": "application/json"
                         },
                         {
-                          "name": "X-My-Message-Header",
-                          "value": "42"
+                          "name": "Link",
+                          "value": "</questions?page=2>; rel=\"next\""
                         }
                       ],
-                      "body": "{ \"message\": \"Hello World!\" }      \n",
-                      "schema": ""
+                      "body": "[\n    {\n        \"question\": \"Favourite programming language?\",\n        \"published_at\": \"2014-11-11T08:40:51.620Z\",\n        \"url\": \"/questions/1\",\n        \"choices\": [\n            {\n                \"choice\": \"Swift\",\n                \"url\": \"/questions/1/choices/1\",\n                \"votes\": 2048\n            }, {\n                \"choice\": \"Python\",\n                \"url\": \"/questions/1/choices/2\",\n                \"votes\": 1024\n            }, {\n                \"choice\": \"Objective-C\",\n                \"url\": \"/questions/1/choices/3\",\n                \"votes\": 512\n            }, {\n                \"choice\": \"Ruby\",\n                \"url\": \"/questions/1/choices/4\",\n                \"votes\": 256\n            }\n        ]\n    }\n]\n",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "[\n    {\n        \"question\": \"Favourite programming language?\",\n        \"published_at\": \"2014-11-11T08:40:51.620Z\",\n        \"url\": \"/questions/1\",\n        \"choices\": [\n            {\n                \"choice\": \"Swift\",\n                \"url\": \"/questions/1/choices/1\",\n                \"votes\": 2048\n            }, {\n                \"choice\": \"Python\",\n                \"url\": \"/questions/1/choices/2\",\n                \"votes\": 1024\n            }, {\n                \"choice\": \"Objective-C\",\n                \"url\": \"/questions/1/choices/3\",\n                \"votes\": 512\n            }, {\n                \"choice\": \"Ruby\",\n                \"url\": \"/questions/1/choices/4\",\n                \"votes\": 256\n            }\n        ]\n    }\n]\n"
+                        }
+                      ]
                     }
                   ]
                 }
               ]
             },
             {
-              "name": "Update a Message",
-              "description": "",
-              "method": "PUT",
+              "name": "Create a new question",
+              "description": "You can create your own question using this action. It takes a JSON dictionary containing a question and a collection of answers in the form of choices.\n\n- question (string) - The question\n\n- choices (array[string]) - A collection of choices.\n\n",
+              "method": "POST",
               "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
               "examples": [
                 {
                   "name": "",
                   "description": "",
                   "requests": [
                     {
-                      "name": "Update Plain Text Message",
-                      "description": "",
-                      "headers": [
-                        {
-                          "name": "Content-Type",
-                          "value": "text/plain"
-                        }
-                      ],
-                      "body": "All your base are belong to us.\n",
-                      "schema": ""
-                    },
-                    {
-                      "name": "Update JSON Message",
+                      "name": "",
                       "description": "",
                       "headers": [
                         {
@@ -141,23 +296,388 @@
                           "value": "application/json"
                         }
                       ],
-                      "body": "{ \"message\": \"All your base are belong to us.\" }\n",
-                      "schema": ""
+                      "body": "    {\n        \"question\": \"Favourite programming language?\",\n        \"choices\": [\n            \"Swift\",\n            \"Python\",\n            \"Objective-C\",\n            \"Ruby\"\n        ]\n    }\n",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "    {\n        \"question\": \"Favourite programming language?\",\n        \"choices\": [\n            \"Swift\",\n            \"Python\",\n            \"Objective-C\",\n            \"Ruby\"\n        ]\n    }\n"
+                        }
+                      ]
                     }
                   ],
                   "responses": [
                     {
-                      "name": "204",
+                      "name": "201",
                       "description": "",
-                      "headers": [],
-                      "body": "",
-                      "schema": ""
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json"
+                        },
+                        {
+                          "name": "Location",
+                          "value": "/questions/2"
+                        }
+                      ],
+                      "body": "    {\n        \"question\": \"Favourite programming language?\",\n        \"published_at\": \"2014-11-11T08:40:51.620Z\",\n        \"url\": \"/questions/2\",\n        \"choices\": [\n            {\n                \"choice\": \"Swift\",\n                \"url\": \"/questions/2/choices/1\",\n                \"votes\": 0\n            }, {\n                \"choice\": \"Python\",\n                \"url\": \"/questions/2/choices/2\",\n                \"votes\": 0\n            }, {\n                \"choice\": \"Objective-C\",\n                \"url\": \"/questions/2/choices/3\",\n                \"votes\": 0\n            }, {\n                \"choice\": \"Ruby\",\n                \"url\": \"/questions/2/choices/4\",\n                \"votes\": 0\n            }\n        ]\n    }\n",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "    {\n        \"question\": \"Favourite programming language?\",\n        \"published_at\": \"2014-11-11T08:40:51.620Z\",\n        \"url\": \"/questions/2\",\n        \"choices\": [\n            {\n                \"choice\": \"Swift\",\n                \"url\": \"/questions/2/choices/1\",\n                \"votes\": 0\n            }, {\n                \"choice\": \"Python\",\n                \"url\": \"/questions/2/choices/2\",\n                \"votes\": 0\n            }, {\n                \"choice\": \"Objective-C\",\n                \"url\": \"/questions/2/choices/3\",\n                \"votes\": 0\n            }, {\n                \"choice\": \"Ruby\",\n                \"url\": \"/questions/2/choices/4\",\n                \"votes\": 0\n            }\n        ]\n    }\n"
+                        }
+                      ]
                     }
                   ]
                 }
               ]
             }
-          ]
+          ],
+          "content": []
+        }
+      ]
+    }
+  ],
+  "content": [
+    {
+      "element": "category",
+      "content": [
+        {
+          "element": "resource",
+          "name": "Polls API Root",
+          "description": "This resource does not have any attributes. Instead it offers the initial API affordances in the form of the links in the JSON body.\n\nIt is recommend to follow the “url” link values or Link headers to get to resources instead of constructing your own URLs to keep your client decoupled from implementation details.\n\n",
+          "uriTemplate": "/",
+          "model": {},
+          "parameters": [],
+          "actions": [
+            {
+              "name": "Retrieve the Entry Point",
+              "description": "",
+              "method": "GET",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [],
+                  "responses": [
+                    {
+                      "name": "200",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json"
+                        }
+                      ],
+                      "body": "{\n    \"questions_url\": \"/questions\"\n}\n",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "{\n    \"questions_url\": \"/questions\"\n}\n"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": []
+        }
+      ]
+    },
+    {
+      "element": "category",
+      "attributes": {
+        "name": "Question"
+      },
+      "content": [
+        {
+          "element": "copy",
+          "content": "Resource related to questions in the API.\n\n"
+        },
+        {
+          "element": "resource",
+          "name": "Question",
+          "description": "A Question object has the following attributes.\n\n- question\n\n- published_at\n\n- url\n\n- choices (an array of Choice objects).\n\n",
+          "uriTemplate": "/questions/{question_id}",
+          "model": {},
+          "parameters": [
+            {
+              "name": "question_id",
+              "description": "ID of the Question in form of an integer",
+              "type": "number",
+              "required": true,
+              "default": "",
+              "example": "1",
+              "values": []
+            }
+          ],
+          "actions": [
+            {
+              "name": "View a question detail",
+              "description": "",
+              "method": "GET",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [],
+                  "responses": [
+                    {
+                      "name": "200",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json"
+                        }
+                      ],
+                      "body": "        {\n            \"question\": \"Favourite programming language?\",\n            \"published_at\": \"2014-11-11T08:40:51.620Z\",\n            \"url\": \"/questions/1\",\n            \"choices\": [\n                {\n                    \"choice\": \"Swift\",\n                    \"url\": \"/questions/1/choices/1\",\n                    \"votes\": 2048\n                }, {\n                    \"choice\": \"Python\",\n                    \"url\": \"/questions/1/choices/2\",\n                    \"votes\": 1024\n                }, {\n                    \"choice\": \"Objective-C\",\n                    \"url\": \"/questions/1/choices/3\",\n                    \"votes\": 512\n                }, {\n                    \"choice\": \"Ruby\",\n                    \"url\": \"/questions/1/choices/4\",\n                    \"votes\": 256\n                }\n            ]\n        }\n",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "        {\n            \"question\": \"Favourite programming language?\",\n            \"published_at\": \"2014-11-11T08:40:51.620Z\",\n            \"url\": \"/questions/1\",\n            \"choices\": [\n                {\n                    \"choice\": \"Swift\",\n                    \"url\": \"/questions/1/choices/1\",\n                    \"votes\": 2048\n                }, {\n                    \"choice\": \"Python\",\n                    \"url\": \"/questions/1/choices/2\",\n                    \"votes\": 1024\n                }, {\n                    \"choice\": \"Objective-C\",\n                    \"url\": \"/questions/1/choices/3\",\n                    \"votes\": 512\n                }, {\n                    \"choice\": \"Ruby\",\n                    \"url\": \"/questions/1/choices/4\",\n                    \"votes\": 256\n                }\n            ]\n        }\n"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": []
+        },
+        {
+          "element": "resource",
+          "name": "Choice",
+          "description": "",
+          "uriTemplate": "/questions/{question_id}/choices/{choice_id}",
+          "model": {},
+          "parameters": [
+            {
+              "name": "question_id",
+              "description": "ID of the Question in form of an integer",
+              "type": "number",
+              "required": true,
+              "default": "",
+              "example": "1",
+              "values": []
+            },
+            {
+              "name": "choice_id",
+              "description": "ID of the Choice in form of an integer",
+              "type": "number",
+              "required": true,
+              "default": "",
+              "example": "1",
+              "values": []
+            }
+          ],
+          "actions": [
+            {
+              "name": "Vote on a Choice",
+              "description": "This action allows you to vote on a question's choice.\n\n",
+              "method": "POST",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [],
+                  "responses": [
+                    {
+                      "name": "201",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json"
+                        }
+                      ],
+                      "body": "{\n    \"url\": \"/questions/1/choices/1\",\n    \"votes\": 1,\n    \"choice\": \"Swift\"\n}\n",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "{\n    \"url\": \"/questions/1/choices/1\",\n    \"votes\": 1,\n    \"choice\": \"Swift\"\n}\n"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": []
+        },
+        {
+          "element": "resource",
+          "name": "Questions collection",
+          "description": "Again, instead of constructing the URLs for the next page. It is **highly** recommended that you follow the `next` link header in the response.\n\n",
+          "uriTemplate": "/questions{?page}",
+          "model": {},
+          "parameters": [
+            {
+              "name": "page",
+              "description": "The page of questions to return",
+              "type": "number",
+              "required": false,
+              "default": "",
+              "example": "1",
+              "values": []
+            }
+          ],
+          "actions": [
+            {
+              "name": "List all questions",
+              "description": "",
+              "method": "GET",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [],
+                  "responses": [
+                    {
+                      "name": "200",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json"
+                        },
+                        {
+                          "name": "Link",
+                          "value": "</questions?page=2>; rel=\"next\""
+                        }
+                      ],
+                      "body": "[\n    {\n        \"question\": \"Favourite programming language?\",\n        \"published_at\": \"2014-11-11T08:40:51.620Z\",\n        \"url\": \"/questions/1\",\n        \"choices\": [\n            {\n                \"choice\": \"Swift\",\n                \"url\": \"/questions/1/choices/1\",\n                \"votes\": 2048\n            }, {\n                \"choice\": \"Python\",\n                \"url\": \"/questions/1/choices/2\",\n                \"votes\": 1024\n            }, {\n                \"choice\": \"Objective-C\",\n                \"url\": \"/questions/1/choices/3\",\n                \"votes\": 512\n            }, {\n                \"choice\": \"Ruby\",\n                \"url\": \"/questions/1/choices/4\",\n                \"votes\": 256\n            }\n        ]\n    }\n]\n",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "[\n    {\n        \"question\": \"Favourite programming language?\",\n        \"published_at\": \"2014-11-11T08:40:51.620Z\",\n        \"url\": \"/questions/1\",\n        \"choices\": [\n            {\n                \"choice\": \"Swift\",\n                \"url\": \"/questions/1/choices/1\",\n                \"votes\": 2048\n            }, {\n                \"choice\": \"Python\",\n                \"url\": \"/questions/1/choices/2\",\n                \"votes\": 1024\n            }, {\n                \"choice\": \"Objective-C\",\n                \"url\": \"/questions/1/choices/3\",\n                \"votes\": 512\n            }, {\n                \"choice\": \"Ruby\",\n                \"url\": \"/questions/1/choices/4\",\n                \"votes\": 256\n            }\n        ]\n    }\n]\n"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "Create a new question",
+              "description": "You can create your own question using this action. It takes a JSON dictionary containing a question and a collection of answers in the form of choices.\n\n- question (string) - The question\n\n- choices (array[string]) - A collection of choices.\n\n",
+              "method": "POST",
+              "parameters": [],
+              "attributes": {
+                "relation": "",
+                "uriTemplate": ""
+              },
+              "content": [],
+              "examples": [
+                {
+                  "name": "",
+                  "description": "",
+                  "requests": [
+                    {
+                      "name": "",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json"
+                        }
+                      ],
+                      "body": "    {\n        \"question\": \"Favourite programming language?\",\n        \"choices\": [\n            \"Swift\",\n            \"Python\",\n            \"Objective-C\",\n            \"Ruby\"\n        ]\n    }\n",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "    {\n        \"question\": \"Favourite programming language?\",\n        \"choices\": [\n            \"Swift\",\n            \"Python\",\n            \"Objective-C\",\n            \"Ruby\"\n        ]\n    }\n"
+                        }
+                      ]
+                    }
+                  ],
+                  "responses": [
+                    {
+                      "name": "201",
+                      "description": "",
+                      "headers": [
+                        {
+                          "name": "Content-Type",
+                          "value": "application/json"
+                        },
+                        {
+                          "name": "Location",
+                          "value": "/questions/2"
+                        }
+                      ],
+                      "body": "    {\n        \"question\": \"Favourite programming language?\",\n        \"published_at\": \"2014-11-11T08:40:51.620Z\",\n        \"url\": \"/questions/2\",\n        \"choices\": [\n            {\n                \"choice\": \"Swift\",\n                \"url\": \"/questions/2/choices/1\",\n                \"votes\": 0\n            }, {\n                \"choice\": \"Python\",\n                \"url\": \"/questions/2/choices/2\",\n                \"votes\": 0\n            }, {\n                \"choice\": \"Objective-C\",\n                \"url\": \"/questions/2/choices/3\",\n                \"votes\": 0\n            }, {\n                \"choice\": \"Ruby\",\n                \"url\": \"/questions/2/choices/4\",\n                \"votes\": 0\n            }\n        ]\n    }\n",
+                      "schema": "",
+                      "content": [
+                        {
+                          "element": "asset",
+                          "attributes": {
+                            "role": "bodyExample"
+                          },
+                          "content": "    {\n        \"question\": \"Favourite programming language?\",\n        \"published_at\": \"2014-11-11T08:40:51.620Z\",\n        \"url\": \"/questions/2\",\n        \"choices\": [\n            {\n                \"choice\": \"Swift\",\n                \"url\": \"/questions/2/choices/1\",\n                \"votes\": 0\n            }, {\n                \"choice\": \"Python\",\n                \"url\": \"/questions/2/choices/2\",\n                \"votes\": 0\n            }, {\n                \"choice\": \"Objective-C\",\n                \"url\": \"/questions/2/choices/3\",\n                \"votes\": 0\n            }, {\n                \"choice\": \"Ruby\",\n                \"url\": \"/questions/2/choices/4\",\n                \"votes\": 0\n            }\n        ]\n    }\n"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "content": []
         }
       ]
     }

--- a/RepresentorTests/Fixtures/blueprint.md
+++ b/RepresentorTests/Fixtures/blueprint.md
@@ -1,0 +1,158 @@
+FORMAT: 1A
+HOST: https://polls.apiblueprint.org/
+
+# Polls
+
+Polls is a simple API allowing consumers to view polls and vote in them.
+
+# Polls API Root [/]
+
+This resource does not have any attributes. Instead it offers the initial
+API affordances in the form of the links in the JSON body.
+
+It is recommend to follow the “url” link values,
+[Link](https://tools.ietf.org/html/rfc5988) or Location headers where
+applicable to retrieve resources. Instead of constructing your own URLs,
+to keep your client decoupled from implementation details.
+
+## Retrieve the Entry Point [GET]
+
++ Response 200 (application/json)
+
+        {
+            "questions_url": "/questions"
+        }
+
+## Group Question
+
+Resources related to questions in the API.
+
+## Question [/questions/{question_id}]
+
++ Parameters
+    + question_id (required, number, `1`) ... ID of the Question in form of an integer
+
++ Attributes
+    + question: Favourite programming language? (string, required)
+    + published_at: 2014-11-11T08:40:51.620Z (string) - An ISO8601 date when the question was published
+    + choices (array[Choice], required) - An array of Choice objects
+    + url: /questions/1 (string)
+
+### View a Questions Detail [GET]
+
++ Response 200 (application/json)
+
+                {
+                    "question": "Favourite programming language?",
+                    "published_at": "2014-11-11T08:40:51.620Z",
+                    "url": "/questions/1",
+                    "choices": [
+                        {
+                            "choice": "Swift",
+                            "url": "/questions/1/choices/1",
+                            "votes": 2048
+                        }, {
+                            "choice": "Python",
+                            "url": "/questions/1/choices/2",
+                            "votes": 1024
+                        }, {
+                            "choice": "Objective-C",
+                            "url": "/questions/1/choices/3",
+                            "votes": 512
+                        }, {
+                            "choice": "Ruby",
+                            "url": "/questions/1/choices/4",
+                            "votes": 256
+                        }
+                    ]
+                }
+
+## Choice [/questions/{question_id}/choices/{choice_id}]
+
++ Parameters
+    + question_id (required, number, `1`) ... ID of the Question in form of an integer
+    + choice_id (required, number, `1`) ... ID of the Choice in form of an integer
+    
++ Attributes
+    + choice: Swift (string, required)
+    + votes: 0 (number, required)
+
+### Vote on a Choice [POST]
+
+This action allows you to vote on a question's choice.
+
++ Response 201
+
+    + Headers
+
+            Location: /questions/1
+
+## Questions Collection [/questions{?page}]
+
++ Parameters
+    + page (optional, number, `1`) ... The page of questions to return
+
+### List All Questions [GET]
+
++ Response 200 (application/json)
+
+    + Headers
+
+            Link: </questions?page=2>; rel="next"
+
+    + Attributes (array[Question])
+
+### Create a New Question [POST]
+
+You may create your own question using this action. It takes a JSON
+object containing a question and a collection of answers in the
+form of choices.
+
++ question (string) - The question
++ choices (array[string]) - A collection of choices.
+
++ Request (application/json)
+
+            {
+                "question": "Favourite programming language?",
+                "choices": [
+                    "Swift",
+                    "Python",
+                    "Objective-C",
+                    "Ruby"
+                ]
+            }
+
++ Response 201 (application/json)
+
+    + Headers
+
+            Location: /questions/2
+
+    + Body
+
+                {
+                    "question": "Favourite programming language?",
+                    "published_at": "2014-11-11T08:40:51.620Z",
+                    "url": "/questions/2",
+                    "choices": [
+                        {
+                            "choice": "Swift",
+                            "url": "/questions/2/choices/1",
+                            "votes": 0
+                        }, {
+                            "choice": "Python",
+                            "url": "/questions/2/choices/2",
+                            "votes": 0
+                        }, {
+                            "choice": "Objective-C",
+                            "url": "/questions/2/choices/3",
+                            "votes": 0
+                        }, {
+                            "choice": "Ruby",
+                            "url": "/questions/2/choices/4",
+                            "votes": 0
+                        }
+                    ]
+                }
+

--- a/RepresentorTests/Fixtures/blueprint.md
+++ b/RepresentorTests/Fixtures/blueprint.md
@@ -72,7 +72,7 @@ Resources related to questions in the API.
 + Parameters
     + question_id (required, number, `1`) ... ID of the Question in form of an integer
     + choice_id (required, number, `1`) ... ID of the Choice in form of an integer
-    
+
 + Attributes
     + choice: Swift (string, required)
     + votes: 0 (number, required)


### PR DESCRIPTION
This pull request adds the "content" attribute for a given refract structure inside of Resources etc. This allows other tools using Representor to get "at" the underlying content (MSON in my case).

The commits include changing the fixture to use a new blueprint AST 3.0 since it includes these new content attributes.
