### PR TITLE
GitHub API media type adapter

### DIFF
--- a/Representor.podspec
+++ b/Representor.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |spec|
       deserialization_spec.dependency 'Representor/HTTP/Transition'
       deserialization_spec.dependency 'Representor/HTTP/Adapters/HAL'
       deserialization_spec.dependency 'Representor/HTTP/Adapters/Siren'
+      deserialization_spec.dependency 'Representor/HTTP/Adapters/GitHub'
       deserialization_spec.source_files = 'Representor/HTTP/HTTPDeserialization.swift'
     end
 
@@ -43,7 +44,12 @@ Pod::Spec.new do |spec|
         blueprint_spec.dependency 'Representor/HTTP/Transition'
         blueprint_spec.source_files = 'Representor/HTTP/APIBlueprint/*.swift'
       end
+
+      adapter_spec.subspec 'GitHub' do |github_spec|
+        github_spec.dependency 'Representor/HTTP/Transition'
+        github_spec.source_files = 'Representor/HTTP/Adapters/HTTPGitHubAdapter.swift'
+      end
+
     end
   end
 end
-

--- a/Representor.xcodeproj/project.pbxproj
+++ b/Representor.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1928DE801B72566D009C4243 /* GitHubAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1928DE7F1B72566D009C4243 /* GitHubAdapter.swift */; };
+		1928DE841B725C07009C4243 /* HTTPGitHubAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1928DE831B725C07009C4243 /* HTTPGitHubAdapter.swift */; };
+		1928DE861B725C38009C4243 /* poll.github.json in Resources */ = {isa = PBXBuildFile; fileRef = 1928DE851B725C38009C4243 /* poll.github.json */; };
 		276A2C001A7BA4B9004BCC6F /* Blueprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276A2BFE1A7BA4B9004BCC6F /* Blueprint.swift */; };
 		276A2C011A7BA4B9004BCC6F /* BlueprintTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276A2BFF1A7BA4B9004BCC6F /* BlueprintTransition.swift */; };
 		276A2C051A7BA4EE004BCC6F /* BlueprintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276A2C031A7BA4EE004BCC6F /* BlueprintTests.swift */; };
@@ -46,6 +49,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1928DE7F1B72566D009C4243 /* GitHubAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GitHubAdapter.swift; path = Adapters/GitHubAdapter.swift; sourceTree = "<group>"; };
+		1928DE831B725C07009C4243 /* HTTPGitHubAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPGitHubAdapter.swift; sourceTree = "<group>"; };
+		1928DE851B725C38009C4243 /* poll.github.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = poll.github.json; sourceTree = "<group>"; };
 		276A2BFE1A7BA4B9004BCC6F /* Blueprint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Blueprint.swift; sourceTree = "<group>"; };
 		276A2BFF1A7BA4B9004BCC6F /* BlueprintTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlueprintTransition.swift; sourceTree = "<group>"; };
 		276A2C031A7BA4EE004BCC6F /* BlueprintTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlueprintTests.swift; sourceTree = "<group>"; };
@@ -144,6 +150,7 @@
 		27931A741A727A280084CB47 /* Adapters */ = {
 			isa = PBXGroup;
 			children = (
+				1928DE831B725C07009C4243 /* HTTPGitHubAdapter.swift */,
 				277D6D9D1A80DD8E0048C6A0 /* HTTPHALAdapter.swift */,
 				27931A751A727A280084CB47 /* HTTPSirenAdapter.swift */,
 			);
@@ -237,8 +244,9 @@
 		77D6433B1A0E6DC5004D4BA0 /* Adapters */ = {
 			isa = PBXGroup;
 			children = (
-				2774DFE11A474164008F41CE /* NSHTTPURLResponseTests.swift */,
+				1928DE7F1B72566D009C4243 /* GitHubAdapter.swift */,
 				77D643391A0E6DC1004D4BA0 /* HALAdapterTests.swift */,
+				2774DFE11A474164008F41CE /* NSHTTPURLResponseTests.swift */,
 				77B507CF1A0EB16100E794BF /* SirenAdapterTests.swift */,
 			);
 			name = Adapters;
@@ -248,6 +256,7 @@
 			isa = PBXGroup;
 			children = (
 				276A2C071A7BA500004BCC6F /* blueprint.json */,
+				1928DE851B725C38009C4243 /* poll.github.json */,
 				77F592341A1B6E1B0070F839 /* poll.hal.json */,
 				77F592351A1B6E1B0070F839 /* poll.siren.json */,
 			);
@@ -351,6 +360,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1928DE861B725C38009C4243 /* poll.github.json in Resources */,
 				77F592371A1B6E1B0070F839 /* poll.hal.json in Resources */,
 				77F592381A1B6E1B0070F839 /* poll.siren.json in Resources */,
 				276A2C081A7BA500004BCC6F /* blueprint.json in Resources */,
@@ -370,6 +380,7 @@
 				770834821A0914CB0008869E /* Transition.swift in Sources */,
 				27931A6E1A7271B10084CB47 /* HTTPTransition.swift in Sources */,
 				276A2C011A7BA4B9004BCC6F /* BlueprintTransition.swift in Sources */,
+				1928DE841B725C07009C4243 /* HTTPGitHubAdapter.swift in Sources */,
 				77BC15361A0A69DC00DD24EF /* RepresentorBuilder.swift in Sources */,
 				27931A711A7272180084CB47 /* HTTPTransitionBuilder.swift in Sources */,
 				276A2C001A7BA4B9004BCC6F /* Blueprint.swift in Sources */,
@@ -391,6 +402,7 @@
 				276A2C061A7BA4EE004BCC6F /* BlueprintTransitionTests.swift in Sources */,
 				770834761A0913860008869E /* RepresentorTests.swift in Sources */,
 				77BC15391A0A6A7700DD24EF /* RepresentorBuilderTests.swift in Sources */,
+				1928DE801B72566D009C4243 /* GitHubAdapter.swift in Sources */,
 				276A2C051A7BA4EE004BCC6F /* BlueprintTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Representor/HTTP/Adapters/HTTPGitHubAdapter.swift
+++ b/Representor/HTTP/Adapters/HTTPGitHubAdapter.swift
@@ -1,0 +1,100 @@
+//
+//  HTTPGitHubAdapter.swift
+//  Representor
+//
+//  Created by Z on 8/5/15.
+//  Copyright (c) 2015 Apiary. All rights reserved.
+//
+
+import Foundation
+
+let selfTranstitionKey = "url"
+let transitionKeySuffix = "_url"
+let selfRelationType = "self"
+
+// Check whether a GitHub object property is a transition
+private func isGitHubTransition(key: String, value: AnyObject) -> Bool {
+  if !(value is String) {
+    return false
+  }
+  
+  if key == selfTranstitionKey || key.hasSuffix(transitionKeySuffix) {
+    return true
+  }
+  
+  return false
+}
+
+// Create a link from a GitHub transition
+private func parseGitHubTransition(key: String, value: AnyObject) -> (relation:String, transition: HTTPTransition) {
+  // relation type
+  let relation: String
+
+  if (key == selfTranstitionKey) {
+    relation = selfRelationType
+  }
+  else {
+    var key = key
+    let range = key.rangeOfString(transitionKeySuffix, options: .BackwardsSearch)
+    key.removeRange(range!)
+    relation = key
+  }
+  
+  let href = value as? String
+  var transition = HTTPTransition(uri: href!)
+  return (relation, transition)
+}
+
+// Check whether a GitHub object property is an embedded resource
+private func isGitHubEmbeddedResource(key: String, value: AnyObject) -> Bool {
+  if let embedded = value as? Dictionary<String, AnyObject> {
+    for (embeddedKey, embeddedValue) in embedded {
+      if isGitHubTransition(embeddedKey, embeddedValue) {
+        return true
+      }
+    }
+  }
+  
+  return false;
+}
+
+// Creates a representor from a GitHub embedded
+private func parseGitHubEmbeddedResource(key: String, value: AnyObject) -> (relation: String, representor: Representor<HTTPTransition>, transition: HTTPTransition) {
+
+  let embedded = deserializeGitHub((value as? Dictionary<String, AnyObject>)!)
+  let transition = embedded.transitions[selfRelationType]
+  
+  return (key, embedded, transition!)
+}
+
+/// Deserialize GitHub application/vnd.github.v3+json
+public func deserializeGitHub(github:[String:AnyObject]) -> Representor<HTTPTransition> {
+  var transitions = [String:HTTPTransition]()
+  var representors = [String:[Representor<HTTPTransition>]]()
+  var attributes = [String:AnyObject]()
+  
+  for (key, value) in github {
+
+    // Transitions
+    if isGitHubTransition(key, value) {
+      let link = parseGitHubTransition(key, value)
+      transitions[link.relation] = link.transition
+      continue
+    }
+    
+    // Embedded resources
+    if isGitHubEmbeddedResource(key, value) {
+      let embedded = parseGitHubEmbeddedResource(key, value)
+      representors[embedded.relation] = [embedded.representor]
+      transitions[embedded.relation] = embedded.transition
+      
+      continue
+    }
+    
+    // Attributes
+    attributes[key] = value
+  }
+  
+  return Representor<HTTPTransition>(transitions: transitions, representors: representors, attributes: attributes)
+}
+

--- a/Representor/HTTP/HTTPDeserialization.swift
+++ b/Representor/HTTP/HTTPDeserialization.swift
@@ -43,6 +43,7 @@ public struct HTTPDeserialization {
   public static var preferredContentTypes:[String] = [
     "application/vnd.siren+json",
     "application/hal+json",
+    "application/vnd.github.v3+json"
   ]
 
   /** Deserialize an NSHTTPURLResponse and body into a Representor.

--- a/Representor/HTTP/HTTPDeserialization.swift
+++ b/Representor/HTTP/HTTPDeserialization.swift
@@ -32,6 +32,11 @@ public struct HTTPDeserialization {
     "application/vnd.siren+json": jsonDeserializer { payload in
       return deserializeSiren(payload)
     },
+    
+    "application/vnd.github.v3+json": jsonDeserializer { payload in
+      return deserializeGitHub(payload)
+    },
+    
   ]
 
   /// An array of the supported content types in order of preference
@@ -51,7 +56,16 @@ public struct HTTPDeserialization {
       if let deserializer = HTTPDeserialization.deserializers[contentType] {
         return deserializer(response: response, body: body)
       }
+      else if let githubMediaType = response.allHeaderFields["X-GitHub-Media-Type"] as? String {
+        // Work around for GitHub media type
+        if githubMediaType == "github.v3; format=json" {
+          if let deserializer = HTTPDeserialization.deserializers["application/vnd.github.v3+json"] {
+            return deserializer(response: response, body: body)
+          }
+        }
+      }
     }
+    
 
     return nil
   }

--- a/RepresentorTests/Adapters/GitHubAdapter.swift
+++ b/RepresentorTests/Adapters/GitHubAdapter.swift
@@ -1,0 +1,28 @@
+//
+//  GitHubAdapter.swift
+//  Representor
+//
+//  Created by Z on 8/5/15.
+//  Copyright (c) 2015 Apiary. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Representor
+
+class GitHubAdapterTests: XCTestCase {
+  func fixture() -> [String:AnyObject] {
+    return JSONFixture("poll.github", self)
+  }
+  
+  func testConversionFromGitHub() {
+    let representor = deserializeGitHub(fixture()) as Representor<HTTPTransition>
+    let representorFixture = PollFixture(self)
+    
+//    let left = representor.representors["next"]![0].transitions["previous"]!
+//    let right = representorFixture.representors["next"]![0].transitions["previous"]!
+//    XCTAssertEqual(left, right)
+    XCTAssertEqual(representor, representorFixture)
+  }
+
+}

--- a/RepresentorTests/Fixtures/poll.github.json
+++ b/RepresentorTests/Fixtures/poll.github.json
@@ -1,0 +1,28 @@
+{
+    "url": "/polls/1/",
+    "next": {
+      "url": "/polls/2/",
+      "previous_url": "/polls/1/",
+      "next_url": "/polls/3/",
+    },
+    "published_at": "2014-11-11T08:40:51.620Z",
+    "question": "Favourite programming language?",
+    "choices": [
+        {
+            "answer": "Swift",
+            "votes": 2048
+        },
+        {
+            "answer": "Python",
+            "votes": 1024
+        },
+        {
+            "answer": "Objective-C",
+            "votes": 512
+        },
+        {
+            "answer": "Ruby",
+            "votes": 256
+        }
+    ]
+}


### PR DESCRIPTION
**For review only – DO NOT MERGE** 

This PR introduces deserialization from GitHub `application/vnd.github.v3+json` media type. 

See https://beta.usecanvas.com/z/github-media-type/b2951c86-c9de-4bb4-a63e-a216d282b2bd for details on how the mapping is done.
