### PR TITLE
Use Swift 2.0 features instead of our own custom ones

### DIFF
--- a/Representor/HTTP/APIBlueprint/Blueprint.swift
+++ b/Representor/HTTP/APIBlueprint/Blueprint.swift
@@ -232,21 +232,9 @@ public struct Payload {
 
 // MARK: AST Parsing
 
-func compactMap<C : CollectionType, T>(source: C, transform: (C.Generator.Element) -> T?) -> [T] {
-  var collection = [T]()
-
-  for element in source {
-    if let item = transform(element) {
-      collection.append(item)
-    }
-  }
-
-  return collection
-}
-
 func parseMetadata(source:[[String:String]]?) -> [Metadata] {
   if let source = source {
-    return compactMap(source) { item in
+    return source.flatMap { item in
       if let name = item["name"] {
         if let value = item["value"] {
           return (name: name, value: value)
@@ -279,7 +267,7 @@ func parseParameter(source:[[String:AnyObject]]?) -> [Parameter] {
 
 func parseActions(source:[[String:AnyObject]]?) -> [Action] {
   if let source = source {
-    return compactMap(source) { item in
+    return source.flatMap { item in
       let name = item["name"] as? String
       let description = item["description"] as? String
       let method = item["method"] as? String
@@ -305,7 +293,7 @@ func parseActions(source:[[String:AnyObject]]?) -> [Action] {
 
 func parseExamples(source:[[String:AnyObject]]?) -> [TransactionExample] {
   if let source = source {
-    return compactMap(source) { item in
+    return source.flatMap { item in
       let name = item["name"] as? String
       let description = item["description"] as? String
       let requests = parsePayloads(item["requests"] as? [[String:AnyObject]])
@@ -324,7 +312,7 @@ func parseExamples(source:[[String:AnyObject]]?) -> [TransactionExample] {
 
 func parsePayloads(source:[[String:AnyObject]]?) -> [Payload] {
   if let source = source {
-    return compactMap(source) { item in
+    return source.flatMap { item in
       let name = item["name"] as? String
       let description = item["description"] as? String
       let headers = parseHeaders(item["headers"] as? [[String:String]])
@@ -345,11 +333,9 @@ func parsePayloads(source:[[String:AnyObject]]?) -> [Payload] {
 
 func parseHeaders(source:[[String:String]]?) -> [Payload.Header] {
   if let source = source {
-    return compactMap(source) { item in
-      if let name = item["name"] {
-        if let value = item["value"] {
-          return (name, value)
-        }
+    return source.flatMap { item in
+      if let name = item["name"], value = item["value"] {
+        return (name, value)
       }
 
       return nil
@@ -361,7 +347,7 @@ func parseHeaders(source:[[String:String]]?) -> [Payload.Header] {
 
 func parseResources(source:[[String:AnyObject]]?) -> [Resource] {
   if let source = source {
-    return compactMap(source) { item in
+    return source.flatMap { item in
       let name = item["name"] as? String
       let description = item["description"] as? String
       let uriTemplate = item["uriTemplate"] as? String
@@ -369,10 +355,8 @@ func parseResources(source:[[String:AnyObject]]?) -> [Resource] {
       let parameters = parseParameter(item["parameters"] as? [[String:AnyObject]])
       let content = item["content"] as? [[String:AnyObject]]
 
-      if let name = name {
-        if let uriTemplate = uriTemplate {
-          return Resource(name: name, description: description, uriTemplate: uriTemplate, parameters: parameters, actions: actions, content: content)
-        }
+      if let name = name, let uriTemplate = uriTemplate {
+        return Resource(name: name, description: description, uriTemplate: uriTemplate, parameters: parameters, actions: actions, content: content)
       }
 
       return nil
@@ -384,7 +368,7 @@ func parseResources(source:[[String:AnyObject]]?) -> [Resource] {
 
 private func parseBlueprintResourceGroups(blueprint:[String:AnyObject]) -> [ResourceGroup] {
   if let resourceGroups = blueprint["resourceGroups"] as? [[String:AnyObject]] {
-    return compactMap(resourceGroups) { dictionary in
+    return resourceGroups.flatMap { dictionary in
       if let name = dictionary["name"] as? String {
         let resources = parseResources(dictionary["resources"] as? [[String:AnyObject]])
         let description = dictionary["description"] as? String

--- a/Representor/HTTP/APIBlueprint/BlueprintTransition.swift
+++ b/Representor/HTTP/APIBlueprint/BlueprintTransition.swift
@@ -8,13 +8,6 @@
 
 import Foundation
 
-extension Array {
-  func contains<T : Equatable>(obj: T) -> Bool {
-    let filtered = self.filter { $0 as? T == obj }
-    return !filtered.isEmpty
-  }
-}
-
 extension Resource {
   func transition(actionName:String) -> HTTPTransition? {
     func filterAction(action:Action) -> Bool {

--- a/Representor/HTTP/APIBlueprint/BlueprintTransition.swift
+++ b/Representor/HTTP/APIBlueprint/BlueprintTransition.swift
@@ -34,12 +34,11 @@ extension Resource {
 
 func parseAttributes(dataStructure:[String:AnyObject], builder:HTTPTransitionBuilder) {
   func isPropertyRequired(property:[String:AnyObject]) -> Bool? {
-    if let valueDefinition = property["valueDefinition"] as? [String:AnyObject] {
-      if let typeDefinition = valueDefinition["typeDefinition"] as? [String:AnyObject] {
-        if let attributes = typeDefinition["attributes"] as? [String] {
-          return attributes.contains("required")
-        }
-      }
+    if let valueDefinition = property["valueDefinition"] as? [String:AnyObject],
+           typeDefinition = valueDefinition["typeDefinition"] as? [String:AnyObject],
+           attributes = typeDefinition["attributes"] as? [String]
+    {
+      return attributes.contains("required")
     }
 
     return nil
@@ -54,12 +53,11 @@ func parseAttributes(dataStructure:[String:AnyObject], builder:HTTPTransitionBui
               continue
             }
 
-            if let content = property["content"] as? [String:AnyObject] {
-              if let name = content["name"] as? [String:AnyObject] {
-                if let literal = name["literal"] as? String {
-                  builder.addAttribute(literal, value: "", defaultValue: "", required: isPropertyRequired(content))
-                }
-              }
+            if let content = property["content"] as? [String:AnyObject],
+                   name = content["name"] as? [String:AnyObject],
+                   literal = name["literal"] as? String
+            {
+              builder.addAttribute(literal, value: "", defaultValue: "", required: isPropertyRequired(content))
             }
           }
         }

--- a/Representor/HTTP/APIBlueprint/BlueprintTransition.swift
+++ b/Representor/HTTP/APIBlueprint/BlueprintTransition.swift
@@ -10,8 +10,8 @@ import Foundation
 
 extension Array {
   func contains<T : Equatable>(obj: T) -> Bool {
-    let filtered = self.filter {$0 as? T == obj}
-    return filtered.count > 0
+    let filtered = self.filter { $0 as? T == obj }
+    return !filtered.isEmpty
   }
 }
 

--- a/Representor/HTTP/Adapters/HTTPHALAdapter.swift
+++ b/Representor/HTTP/Adapters/HTTPHALAdapter.swift
@@ -60,7 +60,7 @@ public func deserializeHAL(hal:[String:AnyObject]) -> Representor<HTTPTransition
 public func serializeHAL(representor:Representor<HTTPTransition>) -> [String:AnyObject] {
   var representation = representor.attributes
 
-  if representor.transitions.count > 0 {
+  if !representor.transitions.isEmpty {
     var links = [String:[String:String]]()
 
     for (relation, transition) in representor.transitions {
@@ -70,7 +70,7 @@ public func serializeHAL(representor:Representor<HTTPTransition>) -> [String:Any
     representation["_links"] = links
   }
 
-  if representor.representors.count > 0 {
+  if !representor.representors.isEmpty {
     var embeddedHALs = [String:[[String:AnyObject]]]()
 
     for (name, representorSet) in representor.representors {

--- a/Representor/HTTP/Adapters/HTTPSirenAdapter.swift
+++ b/Representor/HTTP/Adapters/HTTPSirenAdapter.swift
@@ -122,7 +122,7 @@ public func deserializeSiren(siren:[String:AnyObject]) -> Representor<HTTPTransi
     attributes = properties
   }
 
-  return Representor<HTTPTransition>(transitions: transitions, representors: representors, attributes: attributes, metadata: [:])
+  return Representor<HTTPTransition>(transitions: transitions, representors: representors, attributes: attributes)
 }
 
 /// A function to serialize a HTTP Representor into a Siren structure

--- a/Representor/HTTP/Adapters/HTTPSirenAdapter.swift
+++ b/Representor/HTTP/Adapters/HTTPSirenAdapter.swift
@@ -129,7 +129,7 @@ public func deserializeSiren(siren:[String:AnyObject]) -> Representor<HTTPTransi
 public func serializeSiren(representor:Representor<HTTPTransition>) -> [String:AnyObject] {
   var representation = [String:AnyObject]()
 
-  if representor.representors.count > 0 {
+  if !representor.representors.isEmpty {
     var entities = [[String:AnyObject]]()
 
     for (relation, representorSet) in representor.representors {
@@ -143,20 +143,20 @@ public func serializeSiren(representor:Representor<HTTPTransition>) -> [String:A
     representation["entities"] = entities
   }
 
-  if representor.attributes.count > 0 {
+  if !representor.attributes.isEmpty {
     representation["properties"] = representor.attributes
   }
 
   let links = representor.transitions.filter { $1.method == "GET" }
   let actions = representor.transitions.filter { $1.method != "GET" }
 
-  if links.count > 0 {
+  if !links.isEmpty {
     representation["links"] = links.map { relation, transition in
       return ["rel": [relation], "href": transition.uri]
     }
   }
 
-  if actions.count > 0 {
+  if !actions.isEmpty {
     representation["actions"] = actions.map(transitionToSirenAction)
   }
 

--- a/Representor/HTTP/HTTPTransition.swift
+++ b/Representor/HTTP/HTTPTransition.swift
@@ -12,15 +12,16 @@ import Foundation
 public struct HTTPTransition : TransitionType {
     public typealias Builder = HTTPTransitionBuilder
 
-    public let uri:String
+    public var uri:String
 
     /// The HTTP Method that should be used to make the request
-    public let method:String
-    /// The suggested contentType that should be used to make the request
-    public let suggestedContentTypes:[String]
+    public var method:String
 
-    public let attributes:InputProperties
-    public let parameters:InputProperties
+    /// The suggested contentType that should be used to make the request
+    public var suggestedContentTypes:[String]
+
+    public var attributes:InputProperties
+    public var parameters:InputProperties
 
     public init(uri:String, attributes:InputProperties? = nil, parameters:InputProperties? = nil) {
         self.uri = uri

--- a/Representor/Representor.swift
+++ b/Representor/Representor.swift
@@ -12,15 +12,15 @@ public struct Representor<Transition : TransitionType> : Equatable, Hashable {
   public typealias Builder = RepresentorBuilder<Transition>
 
   /// The transitions available for the representor
-  public let transitions:[String:Transition]
+  public var transitions:[String:Transition]
 
   /// The separate representors embedded in the current representor.
-  public let representors:[String:[Representor]]
+  public var representors:[String:[Representor]]
 
-  public let metadata:[String:String]
+  public var metadata:[String:String]
 
   /// The attributes of the representor
-  public let attributes:[String:AnyObject]
+  public var attributes:[String:AnyObject]
 
   public init(transitions:[String:Transition]? = nil, representors:[String:[Representor]]? = nil, attributes:[String:AnyObject]? = nil, metadata:[String:String]? = nil) {
     self.transitions = transitions ?? [:]

--- a/Representor/Representor.swift
+++ b/Representor/Representor.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+
+/// A representor represents a hypermedia message
 public struct Representor<Transition : TransitionType> : Equatable, Hashable {
   public typealias Builder = RepresentorBuilder<Transition>
 
@@ -79,6 +81,7 @@ public func ==<Transition : TransitionType>(lhs:[String:[Representor<Transition>
 
   return true
 }
+
 
 public func ==<Transition : TransitionType>(lhs:Representor<Transition>, rhs:Representor<Transition>) -> Bool {
   return (


### PR DESCRIPTION
Swift 2.0 (or rather 1.2 I think) introduces it's own `flatMap`, `contains`, etc so we no longer need our own. I've also converted the structures to use `var` instead of `let` to make them easier to change.
