### PR TITLE
silence compiler errors for Swift 3.2

### DIFF
--- a/Sources/Representor.swift
+++ b/Sources/Representor.swift
@@ -83,7 +83,7 @@ public func ==<Value : Equatable>(lhs: [String: [Value]], rhs: [String: [Value]]
 }
 
 
-public func ==<Transition : TransitionType>(lhs: Representor<Transition>, rhs: Representor<Transition>) -> Bool {
+public func ==<Transition>(lhs: Representor<Transition>, rhs: Representor<Transition>) -> Bool {
   return (
     lhs.transitions == rhs.transitions &&
     lhs.representors == rhs.representors &&

--- a/Sources/Transition.swift
+++ b/Sources/Transition.swift
@@ -37,7 +37,7 @@ public func ==(lhs: InputProperty, rhs: InputProperty) -> Bool {
 public typealias InputProperties = [String: InputProperty]
 
 /** Transition instances encapsulate information about interacting with links and forms. */
-public protocol TransitionType: Equatable, Hashable {
+public protocol TransitionType: Hashable {
   associatedtype Builder = TransitionBuilderType
 
   init(uri: String, attributes: InputProperties?, parameters: InputProperties?)


### PR DESCRIPTION
Rely on Swift 3.2 type inference for Equatable conformance